### PR TITLE
fix(tag_guardian): lightgun special devices exceptions added

### DIFF
--- a/scripts/tag_guardian.py
+++ b/scripts/tag_guardian.py
@@ -213,9 +213,29 @@ def validate_special_devices(tag_set):
     }
     addon_tags = [t for t in tag_set if t.startswith('#addon:')]
     genre_tags = [t for t in tag_set if t.startswith('#genre:')]
+
+    # Exception genres (can be present as any subtag in #genre)
+    exception_genres = {
+        'notagame>test',
+        'puzzle'
+    }
+
+    def genre_has_exception(genre_tag):
+        # Remove "#genre:" and split by ":"
+        subtags = genre_tag[len('#genre:'):].split(':')
+        # Check for any exception in subtags (including >)
+        for subtag in subtags:
+            for exc in exception_genres:
+                if exc in subtag:
+                    return True
+        return False
+
     for device in special_devices.keys():
         if any(device in t for t in addon_tags):
-            if not any(special_devices[device] in t for t in genre_tags):
+            # If any genre tag contains an exception, skip warning
+            if any(genre_has_exception(g) for g in genre_tags):
+                continue
+            if not any(special_devices[device] in g for g in genre_tags):
                 warnings.append(f"Game uses {device} but genre:{special_devices[device]} not specified")
     return warnings
 


### PR DESCRIPTION
### Summary

This Pull Request updates and improves the `validate_special_devices` function in `tag_guardian.py`. This function is responsible for issuing warnings when a game uses special devices (such as lightguns and similar peripherals) but does not have the appropriate genre tag.

### Key Changes

- **Special device validation:**  
  The function checks for the presence of special device tags (e.g., `#addon:lightphaser`, `#addon:zapper`, etc.) and ensures that the genre `#genre:shooting` is present.
- **Genre exceptions:**  
  If the game belongs to an exception genre (such as `notagame>test` or `puzzle`), the warning is suppressed even if a special device is used.
- **Robust logic:**  
  The warning is only triggered when appropriate, reducing false positives for edge cases.

### Motivation

The goal is to improve data quality and tag consistency by ensuring that games requiring special peripherals are properly tagged with the relevant genre, except in well-defined exception cases.

### How to Test

1. Add or modify rows in the CSV files with special device tags and various genres.
2. Run the script and verify that:
   - A warning is issued if a special device is used but the `shooting` genre is missing.
   - No warning is issued if the genre is an exception.
