### PR TITLE
fix: update mamerom tags in tags.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,81 @@ The `>` level only applies to its immediate `:` subtag.
 </details>
 
 <details>
-<summary><strong>#compilation</strong> - Compilation of previously released games : ID</summary>
+<summary><strong>#compilation</strong> - Compilation of previously released games ID</summary>
 
+| Subcategory | Description | Children | Children Description |
+|-------------|-------------|----------|--------------------|
+| `:adamandeve` | Adam and Eve |  |  |
+| `:babyboomer` | Baby Boomer |  |  |
+| `:balloonmonster` | Balloon Monster |  |  |
+| `:baseballpros` | Baseball Pros |  |  |
+| `:bignosefreaksout` | Big Nose Freaks Out |  |  |
+| `:bignosethecaveman` | Big Nose the Caveman |  |  |
+| `:blackjack` | Blackjack |  |  |
+| `:bmxsimulator` | BMX Simulator |  |  |
+| `:boomerangkid` | Boomerang Kid |  |  |
+| `:bombliss` | Bombliss |  |  |
+| `:brushroller` | Brush Roller |  |  |
+| `:challengeofthedragon` | Challenge of the Dragon |  |  |
+| `:chiller` | Chiller |  |  |
+| `:cjselephantantics` | C.J.'s Elephant Antics |  |  |
+| `:cosmoscop` | Cosmoscop |  |  |
+| `:crystalmines` | Crystal Mines |  |  |
+| `:deathbots` | Death Bots |  |  |
+| `:deathrace` | Death Race |  |  |
+| `:donkeykong` | Donkey Kong |  |  |
+| `:donkeykongjr` | Donkey Kong Jr. |  |  |
+| `:donkeykongjrnosansuuasobi` | Donkey Kong Jr. No Sansuu Asobi |  |  |
+| `:doublestrike` | Double Strike |  |  |
+| `:duckhunt` | Duck Hunt |  |  |
+| `:dudeswithattitude` | Dudes with Attitude |  |  |
+| `:f15citywar` | F-15 City War |  |  |
+| `:f16renegade` | F-16 Renegade |  |  |
+| `:fantasticdizzy` | Fantastic Dizzy |  |  |
+| `:finalfantasy` | Final Fantasy |  |  |
+| `:finalfantasy2` | Final Fantasy II |  |  |
+| `:galacticcrusader` | Galactic Crusader |  |  |
+| `:godizzygo` | Go Dizzy Go |  |  |
+| `:krazykreatures` | Krazy Kreatures |  |  |
+| `:kingneptunesadventure` | King Neptune's Adventure |  |  |
+| `:linusspacehead` | Linus Spacehead |  |  |
+| `:magiccarpet1001` | Magic Carpet 1001 |  |  |
+| `:mahjonggmen89satsusaretaol` | Mahjong G-Men '89 Satsusareta OL |  |  |
+| `:masterchuandthedrunkardhu` | Master Chu and the Drunkard Hu |  |  |
+| `:menacebeach` | Menace Beach |  |  |
+| `:micromachines` | Micro Machines |  |  |
+| `:moonranger` | Moon Ranger |  |  |
+| `:nekketsukoukoudodgeballbusoccerhen` | Nekketsu Kōkō Dodgeball Bu Soccer Hen |  |  |
+| `:ohpaipee` | Oh Pai Pee |  |  |
+| `:operationsecretstorm` | Operation Secret Storm |  |  |
+| `:pesterminatorthewesternexterminator` | Pesterminator the Western Exterminator |  |  |
+| `:porter` | Porter |  |  |
+| `:pradikusconflict` | Pradikus Conflict |  |  |
+| `:protennis` | Pro Tennis |  |  |
+| `:puzzleideatek` | Puzzle Idea Tek |  |  |
+| `:pyramid1` | Pyramid 1 |  |  |
+| `:raid2020` | Raid 2020 |  |  |
+| `:radrackettennis` | Rad Racquet Tennis |  |  |
+| `:robodemons` | Robo Demons |  |  |
+| `:runningstadium` | Running Stadium |  |  |
+| `:secretscoutinthetempleofdemise` | Secret Scout in the Temple of Demise |  |  |
+| `:sesamestreet123` | Sesame Street 123 |  |  |
+| `:sesamestreetabc` | Sesame Street ABC |  |  |
+| `:shockwave` | Shockwave |  |  |
+| `:soccercm` | Soccer CM |  |  |
+| `:soccersimulator` | Soccer Simulator |  |  |
+| `:solitairenes` | Solitaire NES |  |  |
+| `:stakkm` | Stakk M |  |  |
+| `:stuntbuggies` | Stunt Buggies |  |  |
+| `:superrobinhood` | Super Robin Hood |  |  |
+| `:supermariobros` | Super Mario Bros. | `>supermariobros2`<br>`>supermariobros3`<br>`>yumekoujoudokidokipanic` | Super Mario Bros. 2<br>Super Mario Bros. 3<br>Yume Kōjō Doki Doki Panic |
+| `:tetris2` | Tetris 2 |  |  |
+| `:theadventuresofcaptaincomic` | The Adventures of Captain Comic |  |  |
+| `:theultimatestuntman` | The Ultimate Stuntman |  |  |
+| `:tilesoffate` | Tiles of Fate |  |  |
+| `:treasureislanddizzy` | Treasure Island Dizzy |  |  |
+| `:uschampionshipvball` | US Championship V'Ball |  |  |
+| `:venicebeachvolleyball` | Venice Beach Volleyball |  |  |
 
 </details>
 
@@ -529,6 +602,1278 @@ The `>` level only applies to its immediate `:` subtag.
 <details>
 <summary><strong>#mamerom</strong> - Merged MAME ROM ZIP file > MAME ROM ZIP subfile</summary>
 
+| Subcategory | Description | Children | Children Description |
+|-------------|-------------|----------|--------------------|
+| `:5` | 005 | `>005a` | 005a |
+| `:10yard` | 10yard | `>10yard85`<br>`>10yardj`<br>`>vs10yard`<br>`>vs10yardj`<br>`>vs10yardu` | 10yard85<br>10yardj<br>vs10yard<br>vs10yardj<br>vs10yardu |
+| `:1941` | 1941 | `>1941j`<br>`>1941r1`<br>`>1941u` | 1941j<br>1941r1<br>1941u |
+| `:1942` | 1942 | `>1942a`<br>`>1942b`<br>`>1942h`<br>`>1942w` | 1942a<br>1942b<br>1942h<br>1942w |
+| `:1943` | 1943 | `>1943j`<br>`>1943ja`<br>`>1943jah`<br>`>1943u`<br>`>1943ua` | 1943j<br>1943ja<br>1943jah<br>1943u<br>1943ua |
+| `:1943kai` | 1943kai |  |  |
+| `:1943mii` | 1943mii |  |  |
+| `:1944` | 1944 | `>1944d`<br>`>1944j`<br>`>1944u` | 1944d<br>1944j<br>1944u |
+| `:19xx` | 19xx | `>19xxa`<br>`>19xxar1`<br>`>19xxb`<br>`>19xxd`<br>`>19xxh`<br>`>19xxj`<br>`>19xxjr1`<br>`>19xxjr2`<br>`>19xxu` | 19xxa<br>19xxar1<br>19xxb<br>19xxd<br>19xxh<br>19xxj<br>19xxjr1<br>19xxjr2<br>19xxu |
+| `:2020bb` | 2020bb | `>2020bba` | 2020bba |
+| `:2mindril` | 2mindril | `>2mindrila` | 2mindrila |
+| `:3countb` | 3countb |  |  |
+| `:3wonders` | 3wonders | `>3wondersr1`<br>`>3wondersrh`<br>`>wonder3` | 3wondersr1<br>3wondersrh<br>wonder3 |
+| `:40love` | 40love | `>40lovej` | 40lovej |
+| `:4dwarrio` | 4dwarrio |  |  |
+| `:abcop` | abcop | `>abcopj` | abcopj |
+| `:abunai` | abunai |  |  |
+| `:aburner2` | aburner2 | `>aburner`<br>`>aburner2g` | aburner<br>aburner2g |
+| `:aceattac` | aceattac | `>aceattaca` | aceattaca |
+| `:afighter` | afighter | `>afightera`<br>`>afighterb`<br>`>afighterc`<br>`>afighterd`<br>`>afightere`<br>`>afighterf`<br>`>afighterg`<br>`>afighterh` | afightera<br>afighterb<br>afighterc<br>afighterd<br>afightere<br>afighterf<br>afighterg<br>afighterh |
+| `:ainferno` | ainferno | `>ainfernoj`<br>`>ainfernou` | ainfernoj<br>ainfernou |
+| `:airass` | airass | `>firebarr` | firebarr |
+| `:airduel` | airduel | `>airdueljm72`<br>`>airduelm72`<br>`>airduelu` | airdueljm72<br>airduelm72<br>airduelu |
+| `:airwlkrs` | airwlkrs |  |  |
+| `:ajax` | ajax | `>ajaxj`<br>`>typhoon` | ajaxj<br>typhoon |
+| `:alexkidd` | alexkidd | `>alexkidd1` | alexkidd1 |
+| `:alibaba` | alibaba | `>alibabab` | alibabab |
+| `:alien3` | alien3 | `>alien3j`<br>`>alien3u` | alien3j<br>alien3u |
+| `:aliensyn` | aliensyn | `>aliensyn2`<br>`>aliensyn3`<br>`>aliensyn5`<br>`>aliensyn7`<br>`>aliensynj`<br>`>aliensynjo` | aliensyn2<br>aliensyn3<br>aliensyn5<br>aliensyn7<br>aliensynj<br>aliensynjo |
+| `:alphaho` | alphaho | `>alphahob` | alphahob |
+| `:alpham2` | alpham2 | `>alpham2p` | alpham2p |
+| `:alpine` | alpine | `>alpinea` | alpinea |
+| `:altbeast` | altbeast | `>altbeast2`<br>`>altbeast4`<br>`>altbeast5`<br>`>altbeast6`<br>`>altbeastj`<br>`>altbeastj1`<br>`>altbeastj3` | altbeast2<br>altbeast4<br>altbeast5<br>altbeast6<br>altbeastj<br>altbeastj1<br>altbeastj3 |
+| `:amazon` | amazon | `>amatelas`<br>`>amazont` | amatelas<br>amazont |
+| `:amidar` | amidar | `>amidar1`<br>`>amidarb`<br>`>amidarb2`<br>`>amidarc`<br>`>amidaro`<br>`>amidars`<br>`>amidaru`<br>`>amigo`<br>`>amigo2`<br>`>mandinga`<br>`>mandingac`<br>`>mandingaeg`<br>`>mandingag`<br>`>mandingarf`<br>`>mandinka`<br>`>olmandingc`<br>`>olmandingo` | amidar1<br>amidarb<br>amidarb2<br>amidarc<br>amidaro<br>amidars<br>amidaru<br>amigo<br>amigo2<br>mandinga<br>mandingac<br>mandingaeg<br>mandingag<br>mandingarf<br>mandinka<br>olmandingc<br>olmandingo |
+| `:androdun` | androdun |  |  |
+| `:andromed` | andromed |  |  |
+| `:angelkds` | angelkds |  |  |
+| `:anpanman` | anpanman | `>anpanmana` | anpanmana |
+| `:aodk` | aodk |  |  |
+| `:aof` | aof |  |  |
+| `:aof2` | aof2 |  |  |
+| `:aof3` | aof3 | `>aof3` | aof3 |
+| `:apparel` | apparel |  |  |
+| `:appoooh` | appoooh |  |  |
+| `:aquajack` | aquajack | `>aquajackj`<br>`>aquajacku` | aquajackj<br>aquajacku |
+| `:aquastge` | aquastge |  |  |
+| `:arabfgt` | arabfgt | `>arabfgtj`<br>`>arabfgtu` | arabfgtj<br>arabfgtu |
+| `:arabianm` | arabianm | `>arabianmj`<br>`>arabianmu` | arabianmj<br>arabianmu |
+| `:arescue` | arescue | `>arescuej`<br>`>arescueu` | arescuej<br>arescueu |
+| `:arkanoid` | arkanoid | `>ark1ball`<br>`>arkangc`<br>`>arkangc2`<br>`>arkanoidj`<br>`>arkanoidja`<br>`>arkanoidjb`<br>`>arkanoidjbl`<br>`>arkanoidjbl2`<br>`>arkanoidu`<br>`>arkanoiduo`<br>`>arkatayt`<br>`>arkatayt2`<br>`>arkbloc2`<br>`>arkbloc3`<br>`>arkblock`<br>`>arkgcbl`<br>`>arkgcbla`<br>`>block2` | ark1ball<br>arkangc<br>arkangc2<br>arkanoidj<br>arkanoidja<br>arkanoidjb<br>arkanoidjbl<br>arkanoidjbl2<br>arkanoidu<br>arkanoiduo<br>arkatayt<br>arkatayt2<br>arkbloc2<br>arkbloc3<br>arkblock<br>arkgcbl<br>arkgcbla<br>block2 |
+| `:arknoid2` | arknoid2 | `>arknoid2b`<br>`>arknoid2j`<br>`>arknoid2u` | arknoid2b<br>arknoid2j<br>arknoid2u |
+| `:arkretrn` | arkretrn | `>arkretrnj`<br>`>arkretrnu` | arkretrnj<br>arkretrnu |
+| `:armedf` | armedf | `>armedff` | armedff |
+| `:armwar` | armwar | `>armwara`<br>`>armwarar1`<br>`>armwarb`<br>`>armward`<br>`>armwaru`<br>`>armwaru1`<br>`>pgear`<br>`>pgearr1` | armwara<br>armwarar1<br>armwarb<br>armward<br>armwaru<br>armwaru1<br>pgear<br>pgearr1 |
+| `:armwrest` | armwrest |  |  |
+| `:ashura` | ashura | `>ashuraj`<br>`>ashurau` | ashuraj<br>ashurau |
+| `:aso` | aso | `>alphamis`<br>`>arian` | alphamis<br>arian |
+| `:astorm` | astorm | `>astormj`<br>`>astormu` | astormj<br>astormu |
+| `:astrass` | astrass |  |  |
+| `:astrob` | astrob | `>astrob1`<br>`>astrob2`<br>`>astrob2a`<br>`>astrob2b`<br>`>astrobf`<br>`>astrobg` | astrob1<br>astrob2<br>astrob2a<br>astrob2b<br>astrobf<br>astrobg |
+| `:asuka` | asuka | `>asukaj`<br>`>asukaja` | asukaj<br>asukaja |
+| `:athena` | athena | `>athenab`<br>`>sathena` | athenab<br>sathena |
+| `:atomicp` | atomicp |  |  |
+| `:aurail` | aurail | `>aurail1`<br>`>aurailj` | aurail1<br>aurailj |
+| `:av2mj1bb` | av2mj1bb |  |  |
+| `:av2mj2rg` | av2mj2rg |  |  |
+| `:avmjts` | avmjts |  |  |
+| `:avmjyk` | avmjyk |  |  |
+| `:avsp` | avsp | `>avspa`<br>`>avspd`<br>`>avsph`<br>`>avspj`<br>`>avspu` | avspa<br>avspd<br>avsph<br>avspj<br>avspu |
+| `:b2b` | b2b |  |  |
+| `:bakatono` | bakatono |  |  |
+| `:bakubaku` | bakubaku |  |  |
+| `:ballbomb` | ballbomb |  |  |
+| `:ballbros` | ballbros |  |  |
+| `:balonfgt` | balonfgt |  |  |
+| `:bananadr` | bananadr |  |  |
+| `:bangbead` | bangbead |  |  |
+| `:bankp` | bankp |  |  |
+| `:barline` | barline |  |  |
+| `:bassdx` | bassdx | `>getbass`<br>`>getbassdx`<br>`>getbassur` | getbass<br>getbassdx<br>getbassur |
+| `:batcir` | batcir | `>batcira`<br>`>batcird`<br>`>batcirj` | batcira<br>batcird<br>batcirj |
+| `:batmanfr` | batmanfr |  |  |
+| `:battlnts` | battlnts | `>battlntsa`<br>`>battlntsj` | battlntsa<br>battlntsj |
+| `:battroad` | battroad |  |  |
+| `:bayroute` | bayroute | `>bayroute1`<br>`>bayroutej` | bayroute1<br>bayroutej |
+| `:bbmanw` | bbmanw | `>bbmanwj`<br>`>bbmanwja`<br>`>bomblord`<br>`>newapunk` | bbmanwj<br>bbmanwja<br>bomblord<br>newapunk |
+| `:bbusters` | bbusters | `>bbustersj`<br>`>bbustersja`<br>`>bbustersu`<br>`>bbustersua` | bbustersj<br>bbustersja<br>bbustersu<br>bbustersua |
+| `:bchopper` | bchopper | `>mrheli` | mrheli |
+| `:bel` | bel |  |  |
+| `:benberob` | benberob |  |  |
+| `:bermudat` | bermudat | `>bermudatj` | bermudatj |
+| `:bigevglf` | bigevglf | `>bigevglfj` | bigevglfj |
+| `:bijokkog` | bijokkog |  |  |
+| `:bijokkoy` | bijokkoy |  |  |
+| `:bikkuri` | bikkuri |  |  |
+| `:bioatack` | bioatack |  |  |
+| `:bionicc` | bionicc | `>bionicc1`<br>`>bionicc2`<br>`>bioniccbl`<br>`>bioniccbl2`<br>`>topsecrt`<br>`>topsecrt2` | bionicc1<br>bionicc2<br>bioniccbl<br>bioniccbl2<br>topsecrt<br>topsecrt2 |
+| `:bjourney` | bjourney |  |  |
+| `:bking` | bking |  |  |
+| `:bking2` | bking2 |  |  |
+| `:bking3` | bking3 |  |  |
+| `:blazstar` | blazstar |  |  |
+| `:blkpnthr` | blkpnthr |  |  |
+| `:blktiger` | blktiger | `>blkdrgon`<br>`>blktigera` | blkdrgon<br>blktigera |
+| `:block` | block | `>blockj`<br>`>blockr1`<br>`>blockr2` | blockj<br>blockr1<br>blockr2 |
+| `:blockfvr` | blockfvr |  |  |
+| `:blockgal` | blockgal |  |  |
+| `:bloxeed` | bloxeed | `>bloxeedc`<br>`>bloxeedu` | bloxeedc<br>bloxeedu |
+| `:bmaster` | bmaster | `>crossbld` | crossbld |
+| `:bnglngby` | bnglngby |  |  |
+| `:bnzabros` | bnzabros | `>bnzabrosj` | bnzabrosj |
+| `:bodyslam` | bodyslam | `>dumpmtmt` | dumpmtmt |
+| `:bonzeadv` | bonzeadv | `>bonzeadvo`<br>`>bonzeadvp`<br>`>bonzeadvp2`<br>`>bonzeadvu`<br>`>jigkmgri`<br>`>jigkmgria` | bonzeadvo<br>bonzeadvp<br>bonzeadvp2<br>bonzeadvu<br>jigkmgri<br>jigkmgria |
+| `:borench` | borench | `>borencha`<br>`>borenchj` | borencha<br>borenchj |
+| `:brain` | brain |  |  |
+| `:brdrline` | brdrline | `>brdrlinb`<br>`>brdrlinet`<br>`>brdrlins`<br>`>starrkr` | brdrlinb<br>brdrlinet<br>brdrlins<br>starrkr |
+| `:breakers` | breakers |  |  |
+| `:breakrev` | breakrev |  |  |
+| `:brival` | brival | `>brivalj` | brivalj |
+| `:bshark` | bshark | `>bsharkj`<br>`>bsharkjjs`<br>`>bsharku` | bsharkj<br>bsharkjjs<br>bsharku |
+| `:bstars` | bstars |  |  |
+| `:bstars2` | bstars2 |  |  |
+| `:btlecity` | btlecity |  |  |
+| `:bubblem` | bubblem | `>bubblemj`<br>`>bubblemu` | bubblemj<br>bubblemu |
+| `:bublbob2` | bublbob2 | `>bublbob2e`<br>`>bublbob2j`<br>`>bublbob2o`<br>`>bublbob2p`<br>`>bublbob2u`<br>`>bubsymphb` | bublbob2e<br>bublbob2j<br>bublbob2o<br>bublbob2p<br>bublbob2u<br>bubsymphb |
+| `:bublbobl` | bublbobl | `>bbredux`<br>`>boblbobl`<br>`>bub68705`<br>`>bub8749`<br>`>bublbobl1`<br>`>bublboblb`<br>`>bublboblp`<br>`>bublboblr`<br>`>bublboblr1`<br>`>bublcave`<br>`>bublcave10`<br>`>bublcave11`<br>`>dland`<br>`>sboblbobl`<br>`>sboblbobla`<br>`>sboblboblb`<br>`>sboblboblc`<br>`>sboblbobld`<br>`>sboblboble`<br>`>sboblboblf` | bbredux<br>boblbobl<br>bub68705<br>bub8749<br>bublbobl1<br>bublboblb<br>bublboblp<br>bublboblr<br>bublboblr1<br>bublcave<br>bublcave10<br>bublcave11<br>dland<br>sboblbobl<br>sboblbobla<br>sboblboblb<br>sboblboblc<br>sboblbobld<br>sboblboble<br>sboblboblf |
+| `:buckrog` | buckrog | `>buckrogn`<br>`>buckrogn2`<br>`>zoom909` | buckrogn<br>buckrogn2<br>zoom909 |
+| `:buggychl` | buggychl | `>buggychlt` | buggychlt |
+| `:bullet` | bullet |  |  |
+| `:bullfgt` | bullfgt | `>thetogyu` | thetogyu |
+| `:burningf` | burningf | `>burningfp`<br>`>burningfpa`<br>`>burningfpb` | burningfp<br>burningfpa<br>burningfpb |
+| `:bygone` | bygone |  |  |
+| `:cachat` | cachat | `>tubeit` | tubeit |
+| `:cadash` | cadash | `>cadashf`<br>`>cadashg`<br>`>cadashgo`<br>`>cadashi`<br>`>cadashj`<br>`>cadashj1`<br>`>cadashjo`<br>`>cadashs`<br>`>cadashu`<br>`>cadashu1` | cadashf<br>cadashg<br>cadashgo<br>cadashi<br>cadashj<br>cadashj1<br>cadashjo<br>cadashs<br>cadashu<br>cadashu1 |
+| `:cameltry` | cameltry | `>cameltrya`<br>`>cameltryj` | cameltrya<br>cameltryj |
+| `:canvas` | canvas |  |  |
+| `:captcomm` | captcomm | `>captcommj`<br>`>captcommjr1`<br>`>captcommr1`<br>`>captcommu` | captcommj<br>captcommjr1<br>captcommr1<br>captcommu |
+| `:carhntds` | carhntds |  |  |
+| `:carnival` | carnival | `>carnivalb`<br>`>carnivalc`<br>`>carnivalca`<br>`>carnivalh`<br>`>carnivalha`<br>`>carnivalmm` | carnivalb<br>carnivalc<br>carnivalca<br>carnivalh<br>carnivalha<br>carnivalmm |
+| `:cavelon` | cavelon |  |  |
+| `:cawing` | cawing | `>cawingj`<br>`>cawingr1`<br>`>cawingu`<br>`>cawingur1` | cawingj<br>cawingr1<br>cawingu<br>cawingur1 |
+| `:cbombers` | cbombers | `>cbombersj`<br>`>cbombersp` | cbombersj<br>cbombersp |
+| `:cclimber` | cclimber | `>ccboot`<br>`>ccboot2`<br>`>ccbootmm`<br>`>ccbootmr`<br>`>cclimbera`<br>`>cclimberj`<br>`>cclimbroper`<br>`>cclimbrrod` | ccboot<br>ccboot2<br>ccbootmm<br>ccbootmr<br>cclimbera<br>cclimberj<br>cclimbroper<br>cclimbrrod |
+| `:cclimbr2` | cclimbr2 | `>cclimbr2a` | cclimbr2a |
+| `:chaknpop` | chaknpop |  |  |
+| `:champwr` | champwr | `>champwrj`<br>`>champwru` | champwrj<br>champwru |
+| `:changela` | changela |  |  |
+| `:chasehq` | chasehq | `>chasehqj`<br>`>chasehqju`<br>`>chasehqu` | chasehqj<br>chasehqju<br>chasehqu |
+| `:chinhero` | chinhero | `>chinhero2`<br>`>chinhero3`<br>`>chinherot` | chinhero2<br>chinhero3<br>chinherot |
+| `:chinmoku` | chinmoku |  |  |
+| `:choko` | choko |  |  |
+| `:choplift` | choplift | `>chopliftu` | chopliftu |
+| `:chopliftu` | chopliftu | `>chopliftbl` | chopliftbl |
+| `:chopper` | chopper | `>choppera`<br>`>chopperb`<br>`>legofair` | choppera<br>chopperb<br>legofair |
+| `:chukatai` | chukatai | `>chukataij`<br>`>chukataija`<br>`>chukataiu` | chukataij<br>chukataija<br>chukataiu |
+| `:circusc` | circusc | `>circusc2`<br>`>circusc3`<br>`>circusc4`<br>`>circuscc`<br>`>circusce` | circusc2<br>circusc3<br>circusc4<br>circuscc<br>circusce |
+| `:citylove` | citylove | `>mcitylov` | mcitylov |
+| `:ckong` | ckong | `>bigkong`<br>`>bigkonggx`<br>`>ckongalc`<br>`>ckongcv`<br>`>ckongdks`<br>`>ckongg`<br>`>ckonggx`<br>`>ckongis`<br>`>ckongmc`<br>`>ckongmc2`<br>`>ckongo`<br>`>ckongs`<br>`>dking`<br>`>monkeyd` | bigkong<br>bigkonggx<br>ckongalc<br>ckongcv<br>ckongdks<br>ckongg<br>ckonggx<br>ckongis<br>ckongmc<br>ckongmc2<br>ckongo<br>ckongs<br>dking<br>monkeyd |
+| `:ckongpt2` | ckongpt2 | `>ckongpt2b`<br>`>ckongpt2b2`<br>`>ckongpt2j`<br>`>ckongpt2ss` | ckongpt2b<br>ckongpt2b2<br>ckongpt2j<br>ckongpt2ss |
+| `:ckongpt2a` | ckongpt2a | `>ckongpt2jeu` | ckongpt2jeu |
+| `:cleopatr` | cleopatr | `>cleopatro` | cleopatro |
+| `:cltchitr` | cltchitr | `>cltchitrj` | cltchitrj |
+| `:club90s` | club90s | `>club90sa`<br>`>lovehous` | club90sa<br>lovehous |
+| `:cluclu` | cluclu |  |  |
+| `:cmehyou` | cmehyou |  |  |
+| `:cntrygrl` | cntrygrl | `>cntrygrla`<br>`>fruitbun` | cntrygrla<br>fruitbun |
+| `:colmns97` | colmns97 |  |  |
+| `:colony7` | colony7 | `>colony7a` | colony7a |
+| `:columns` | columns | `>columnsj`<br>`>columnsu` | columnsj<br>columnsu |
+| `:columns2` | columns2 | `>column2j` | column2j |
+| `:combh` | combh |  |  |
+| `:commando` | commando | `>commandob`<br>`>commandob2`<br>`>commandob3`<br>`>commandoj`<br>`>commandou`<br>`>commandou2`<br>`>sinvasn` | commandob<br>commandob2<br>commandob3<br>commandoj<br>commandou<br>commandou2<br>sinvasn |
+| `:commandw` | commandw |  |  |
+| `:complexx` | complexx |  |  |
+| `:congo` | congo | `>congoa`<br>`>tiptop` | congoa<br>tiptop |
+| `:contcirc` | contcirc | `>contcircj`<br>`>contcircu`<br>`>contcircua` | contcircj<br>contcircu<br>contcircua |
+| `:coolridr` | coolridr |  |  |
+| `:cop01` | cop01 | `>cop01a` | cop01a |
+| `:cosmccop` | cosmccop | `>gallop`<br>`>gallopm72` | gallop<br>gallopm72 |
+| `:cothello` | cothello |  |  |
+| `:cotton` | cotton | `>cottonj`<br>`>cottonja`<br>`>cottonu` | cottonj<br>cottonja<br>cottonu |
+| `:cotton2` | cotton2 |  |  |
+| `:cottonbm` | cottonbm |  |  |
+| `:countryc` | countryc |  |  |
+| `:crbaloon` | crbaloon | `>crbaloon2` | crbaloon2 |
+| `:crimec` | crimec | `>crimecj`<br>`>crimecu` | crimecj<br>crimecu |
+| `:critcrsh` | critcrsh | `>tatacot` | tatacot |
+| `:crkdown` | crkdown | `>crkdownj`<br>`>crkdownu` | crkdownj<br>crkdownu |
+| `:crsword` | crsword |  |  |
+| `:crystal2` | crystal2 |  |  |
+| `:crystalg` | crystalg |  |  |
+| `:csclub` | csclub | `>csclub1`<br>`>csclub1d`<br>`>cscluba`<br>`>csclubh`<br>`>csclubj`<br>`>csclubjy` | csclub1<br>csclub1d<br>cscluba<br>csclubh<br>csclubj<br>csclubjy |
+| `:cstlevna` | cstlevna |  |  |
+| `:ctomaday` | ctomaday |  |  |
+| `:cubybop` | cubybop |  |  |
+| `:cupfinal` | cupfinal | `>hthero93`<br>`>hthero93u` | hthero93<br>hthero93u |
+| `:cworld` | cworld |  |  |
+| `:cworld2j` | cworld2j | `>cworld2ja`<br>`>cworld2jb` | cworld2ja<br>cworld2jb |
+| `:cyberlip` | cyberlip |  |  |
+| `:cybots` | cybots | `>cybotsj`<br>`>cybotsjd`<br>`>cybotsu`<br>`>cybotsud` | cybotsj<br>cybotsjd<br>cybotsu<br>cybotsud |
+| `:dacholer` | dacholer |  |  |
+| `:daikaiju` | daikaiju |  |  |
+| `:dakkochn` | dakkochn |  |  |
+| `:danchih` | danchih |  |  |
+| `:danchiq` | danchiq |  |  |
+| `:dangar` | dangar | `>dangara`<br>`>dangarb`<br>`>dangarbt`<br>`>dangarj` | dangara<br>dangarb<br>dangarbt<br>dangarj |
+| `:dankuga` | dankuga |  |  |
+| `:darius` | darius | `>dariuse`<br>`>dariusj`<br>`>dariuso`<br>`>dariusu` | dariuse<br>dariusj<br>dariuso<br>dariusu |
+| `:darius2` | darius2 | `>darius2d`<br>`>darius2do`<br>`>sagaia` | darius2d<br>darius2do<br>sagaia |
+| `:dariusg` | dariusg | `>dariusgj`<br>`>dariusgu` | dariusgj<br>dariusgu |
+| `:dariusgx` | dariusgx |  |  |
+| `:darkedge` | darkedge | `>darkedgej` | darkedgej |
+| `:dayto2pe` | dayto2pe |  |  |
+| `:daytona` | daytona | `>daytona93`<br>`>daytonam`<br>`>daytonas`<br>`>daytonase`<br>`>daytonat`<br>`>daytonata` | daytona93<br>daytonam<br>daytonas<br>daytonase<br>daytonat<br>daytonata |
+| `:daytona2` | daytona2 |  |  |
+| `:dblaxle` | dblaxle | `>dblaxleu`<br>`>dblaxleul`<br>`>pwheelsj` | dblaxleu<br>dblaxleul<br>pwheelsj |
+| `:dbreed` | dbreed | `>dbreedjm72`<br>`>dbreedm72` | dbreedjm72<br>dbreedm72 |
+| `:dbzvrvs` | dbzvrvs |  |  |
+| `:dcclub` | dcclub | `>dcclubfd`<br>`>dcclubj` | dcclubfd<br>dcclubj |
+| `:ddcrew` | ddcrew | `>ddcrew2`<br>`>ddcrewj`<br>`>ddcrewj2`<br>`>ddcrewu` | ddcrew2<br>ddcrewj<br>ddcrewj2<br>ddcrewu |
+| `:dddoor` | dddoor |  |  |
+| `:ddribble` | ddribble | `>ddribblep` | ddribblep |
+| `:ddsom` | ddsom | `>ddsoma`<br>`>ddsomar1`<br>`>ddsomb`<br>`>ddsomh`<br>`>ddsomj`<br>`>ddsomjr1`<br>`>ddsomjr2`<br>`>ddsomr1`<br>`>ddsomr2`<br>`>ddsomr3`<br>`>ddsomu`<br>`>ddsomud`<br>`>ddsomur1` | ddsoma<br>ddsomar1<br>ddsomb<br>ddsomh<br>ddsomj<br>ddsomjr1<br>ddsomjr2<br>ddsomr1<br>ddsomr2<br>ddsomr3<br>ddsomu<br>ddsomud<br>ddsomur1 |
+| `:ddtod` | ddtod | `>ddtoda`<br>`>ddtodar1`<br>`>ddtodh`<br>`>ddtodhr1`<br>`>ddtodhr2`<br>`>ddtodj`<br>`>ddtodjr1`<br>`>ddtodjr2`<br>`>ddtodr1`<br>`>ddtodu`<br>`>ddtodur1` | ddtoda<br>ddtodar1<br>ddtodh<br>ddtodhr1<br>ddtodhr2<br>ddtodj<br>ddtodjr1<br>ddtodjr2<br>ddtodr1<br>ddtodu<br>ddtodur1 |
+| `:ddux` | ddux | `>ddux1`<br>`>dduxj2` | ddux1<br>dduxj2 |
+| `:deadconx` | deadconx | `>deadconxj` | deadconxj |
+| `:decathlt` | decathlt | `>decathlto` | decathlto |
+| `:demoneye` | demoneye |  |  |
+| `:depthch` | depthch | `>depthcho`<br>`>subhunt` | depthcho<br>subhunt |
+| `:desert` | desert |  |  |
+| `:desertbr` | desertbr | `>desertbrj` | desertbrj |
+| `:dfjail` | dfjail |  |  |
+| `:dicegame` | dicegame |  |  |
+| `:diehard` | diehard | `>dnmtdeka` | dnmtdeka |
+| `:digger` | digger |  |  |
+| `:diggerma` | diggerma |  |  |
+| `:dimahoo` | dimahoo | `>dimahoou`<br>`>dimahooud`<br>`>gmahou` | dimahoou<br>dimahooud<br>gmahou |
+| `:dino` | dino | `>dinoa`<br>`>dinoj`<br>`>dinou` | dinoa<br>dinoj<br>dinou |
+| `:dinorex` | dinorex | `>dinorexj`<br>`>dinorexu` | dinorexj<br>dinorexu |
+| `:dirtdvls` | dirtdvls | `>dirtdvlsau`<br>`>dirtdvlsg`<br>`>dirtdvlsj`<br>`>dirtdvlsu` | dirtdvlsau<br>dirtdvlsg<br>dirtdvlsj<br>dirtdvlsu |
+| `:dkong` | dkong | `>dkongf`<br>`>dkonghrd`<br>`>dkonghs`<br>`>dkongike`<br>`>dkongj`<br>`>dkongj1`<br>`>dkongjo`<br>`>dkongjrc`<br>`>dkongo`<br>`>dkongpe`<br>`>dkongx`<br>`>dkongx11` | dkongf<br>dkonghrd<br>dkonghs<br>dkongike<br>dkongj<br>dkongj1<br>dkongjo<br>dkongjrc<br>dkongo<br>dkongpe<br>dkongx<br>dkongx11 |
+| `:dkong3` | dkong3 | `>dkong3abl`<br>`>dkong3b`<br>`>dkong3hs`<br>`>dkong3j` | dkong3abl<br>dkong3b<br>dkong3hs<br>dkong3j |
+| `:dkongjr` | dkongjr | `>dkingjr`<br>`>dkingjrv`<br>`>dkongddk`<br>`>dkongjnrj`<br>`>dkongjr2`<br>`>dkongjrb`<br>`>dkongjre`<br>`>dkongjrhs`<br>`>dkongjrj`<br>`>dkongjrm`<br>`>dkongjrmc`<br>`>dkongjrpb`<br>`>jrking`<br>`>maguila` | dkingjr<br>dkingjrv<br>dkongddk<br>dkongjnrj<br>dkongjr2<br>dkongjrb<br>dkongjre<br>dkongjrhs<br>dkongjrj<br>dkongjrm<br>dkongjrmc<br>dkongjrpb<br>jrking<br>maguila |
+| `:dleague` | dleague | `>dleaguej` | dleaguej |
+| `:doa` | doa | `>doaa`<br>`>doaae`<br>`>doab` | doaa<br>doaae<br>doab |
+| `:dockman` | dockman | `>dockmanb`<br>`>dockmanc`<br>`>porter`<br>`>portera`<br>`>portman`<br>`>portmanj`<br>`>theportr` | dockmanb<br>dockmanc<br>porter<br>portera<br>portman<br>portmanj<br>theportr |
+| `:dokaben` | dokaben |  |  |
+| `:dondokod` | dondokod | `>dondokodj`<br>`>dondokodu` | dondokodj<br>dondokodu |
+| `:dotrikun` | dotrikun | `>dotrikun2` | dotrikun2 |
+| `:doubledr` | doubledr |  |  |
+| `:dragonsh` | dragonsh |  |  |
+| `:driftout` | driftout | `>driftoutct`<br>`>driftoutj`<br>`>driveout` | driftoutct<br>driftoutj<br>driveout |
+| `:drmario` | drmario |  |  |
+| `:drtoppel` | drtoppel | `>drtoppelj`<br>`>drtoppelu` | drtoppelj<br>drtoppelu |
+| `:dsoccr94` | dsoccr94 | `>dsoccr94j`<br>`>dsoccr94k` | dsoccr94j<br>dsoccr94k |
+| `:dstlk` | dstlk | `>dstlka`<br>`>dstlkh`<br>`>dstlku`<br>`>dstlku1d`<br>`>dstlkur1`<br>`>vampj`<br>`>vampja`<br>`>vampjr1` | dstlka<br>dstlkh<br>dstlku<br>dstlku1d<br>dstlkur1<br>vampj<br>vampja<br>vampjr1 |
+| `:duckhunt` | duckhunt |  |  |
+| `:dunkshot` | dunkshot | `>dunkshota`<br>`>dunkshoto` | dunkshota<br>dunkshoto |
+| `:dynabb` | dynabb |  |  |
+| `:dynabb97` | dynabb97 |  |  |
+| `:dynablst` | dynablst | `>atompunk`<br>`>bombrman` | atompunk<br>bombrman |
+| `:dynamcop` | dynamcop | `>dynamcopb`<br>`>dynamcopc`<br>`>dyndeka2`<br>`>dyndeka2b` | dynamcopb<br>dynamcopc<br>dyndeka2<br>dyndeka2b |
+| `:dynamski` | dynamski |  |  |
+| `:dynwar` | dynwar | `>dynwara`<br>`>dynwarj`<br>`>dynwarjr` | dynwara<br>dynwarj<br>dynwarjr |
+| `:earthjkr` | earthjkr | `>earthjkra`<br>`>earthjkrb`<br>`>earthjkrp` | earthjkra<br>earthjkrb<br>earthjkrp |
+| `:eca` | eca | `>ecaj`<br>`>ecap`<br>`>ecau` | ecaj<br>ecap<br>ecau |
+| `:ecofghtr` | ecofghtr | `>ecofghtra`<br>`>ecofghtrd`<br>`>ecofghtrh`<br>`>ecofghtru`<br>`>ecofghtru1`<br>`>uecology` | ecofghtra<br>ecofghtrd<br>ecofghtrh<br>ecofghtru<br>ecofghtru1<br>uecology |
+| `:eightman` | eightman |  |  |
+| `:ejihon` | ejihon |  |  |
+| `:elandore` | elandore |  |  |
+| `:elecyoyo` | elecyoyo | `>elecyoyoa` | elecyoyoa |
+| `:elevator` | elevator | `>elevatora`<br>`>elevatorb` | elevatora<br>elevatorb |
+| `:elvactr` | elvactr | `>elvactrj`<br>`>elvactru` | elvactrj<br>elvactru |
+| `:enduror` | enduror | `>enduror1`<br>`>endurora`<br>`>endurorb` | enduror1<br>endurora<br>endurorb |
+| `:enforce` | enforce | `>enforcej`<br>`>enforceja` | enforcej<br>enforceja |
+| `:eswat` | eswat | `>eswatj`<br>`>eswatj1`<br>`>eswatu` | eswatj<br>eswatj1<br>eswatu |
+| `:eto` | eto | `>etoa` | etoa |
+| `:euroch92` | euroch92 | `>euroch92j` | euroch92j |
+| `:excitebk` | excitebk | `>excitebkj`<br>`>excitebko` | excitebkj<br>excitebko |
+| `:exctleag` | exctleag |  |  |
+| `:exedexes` | exedexes | `>savgbees` | savgbees |
+| `:extrmatn` | extrmatn | `>extrmatnj`<br>`>extrmatnu`<br>`>extrmatnur` | extrmatnj<br>extrmatnu<br>extrmatnur |
+| `:exzisus` | exzisus | `>exzisusa`<br>`>exzisust` | exzisusa<br>exzisust |
+| `:f1dream` | f1dream |  |  |
+| `:f1en` | f1en | `>f1enj`<br>`>f1enu` | f1enj<br>f1enu |
+| `:f1lap` | f1lap | `>f1lapj`<br>`>f1lapt` | f1lapj<br>f1lapt |
+| `:fantasyu` | fantasyu | `>fantasyg`<br>`>fantasyg2`<br>`>fantasyj` | fantasyg<br>fantasyg2<br>fantasyj |
+| `:fantzn2` | fantzn2 |  |  |
+| `:fantzn2x` | fantzn2x | `>fantzn2xp` | fantzn2xp |
+| `:fantzone` | fantzone | `>fantzone1`<br>`>fantzonee`<br>`>fantzonep`<br>`>fantzonepr` | fantzone1<br>fantzonee<br>fantzonep<br>fantzonepr |
+| `:fanzonem` | fanzonem |  |  |
+| `:fatfursp` | fatfursp | `>fatfurspa` | fatfurspa |
+| `:fatfury1` | fatfury1 |  |  |
+| `:fatfury2` | fatfury2 |  |  |
+| `:fatfury3` | fatfury3 |  |  |
+| `:fbfrenzy` | fbfrenzy |  |  |
+| `:ffight` | ffight | `>ffighta`<br>`>ffightae`<br>`>ffightj`<br>`>ffightj1`<br>`>ffightj2`<br>`>ffightj3`<br>`>ffightj4`<br>`>ffightu`<br>`>ffightu1`<br>`>ffightua`<br>`>ffightub`<br>`>ffightuc` | ffighta<br>ffightae<br>ffightj<br>ffightj1<br>ffightj2<br>ffightj3<br>ffightj4<br>ffightu<br>ffightu1<br>ffightua<br>ffightub<br>ffightuc |
+| `:ffreveng` | ffreveng | `>ffrevng10` | ffrevng10 |
+| `:fgoal` | fgoal | `>fgoala` | fgoala |
+| `:fhawk` | fhawk | `>fhawkj` | fhawkj |
+| `:fhboxers` | fhboxers |  |  |
+| `:fieldday` | fieldday | `>undoukai` | undoukai |
+| `:fightfev` | fightfev | `>fightfeva` | fightfeva |
+| `:finalb` | finalb | `>finalbj`<br>`>finalbu` | finalbj<br>finalbu |
+| `:finalizr` | finalizr | `>finalizra`<br>`>finalizrb` | finalizra<br>finalizrb |
+| `:findlove` | findlove |  |  |
+| `:firebatl` | firebatl |  |  |
+| `:fitegolf` | fitegolf | `>fitegolfu`<br>`>fitegolfua` | fitegolfu<br>fitegolfua |
+| `:flicky` | flicky |  |  |
+| `:flipshot` | flipshot |  |  |
+| `:flstory` | flstory | `>flstoryo` | flstoryo |
+| `:footchmp` | footchmp | `>footchmpbl`<br>`>hthero` | footchmpbl<br>hthero |
+| `:forgottn` | forgottn | `>forgottna`<br>`>forgottnj`<br>`>forgottnu`<br>`>forgottnua`<br>`>forgottnuaa`<br>`>forgottnuc`<br>`>forgottnue`<br>`>lostwrld`<br>`>lostwrldo` | forgottna<br>forgottnj<br>forgottnu<br>forgottnua<br>forgottnuaa<br>forgottnuc<br>forgottnue<br>lostwrld<br>lostwrldo |
+| `:fpoint` | fpoint | `>fpoint1` | fpoint1 |
+| `:friskyt` | friskyt | `>friskyta`<br>`>friskytb` | friskyta<br>friskytb |
+| `:frogger` | frogger | `>frogf`<br>`>frogg`<br>`>froggeg`<br>`>froggeram`<br>`>froggereb`<br>`>froggermc`<br>`>froggers`<br>`>froggers1`<br>`>froggers2`<br>`>froggers3`<br>`>froggert`<br>`>froggerv`<br>`>froggervd` | frogf<br>frogg<br>froggeg<br>froggeram<br>froggereb<br>froggermc<br>froggers<br>froggers1<br>froggers2<br>froggers3<br>froggert<br>froggerv<br>froggervd |
+| `:frogs` | frogs |  |  |
+| `:froman2b` | froman2b |  |  |
+| `:fsoccer` | fsoccer | `>fsoccerb`<br>`>fsoccerba`<br>`>fsoccerj` | fsoccerb<br>fsoccerba<br>fsoccerj |
+| `:futspy` | futspy |  |  |
+| `:fvipers` | fvipers | `>fvipersb` | fvipersb |
+| `:fvipers2` | fvipers2 | `>fvipers2o` | fvipers2o |
+| `:ga2` | ga2 | `>ga2j`<br>`>ga2u` | ga2j<br>ga2u |
+| `:gal10ren` | gal10ren |  |  |
+| `:galastrm` | galastrm |  |  |
+| `:galaxyfg` | galaxyfg |  |  |
+| `:galivan` | galivan | `>galivan2`<br>`>galivan3` | galivan2<br>galivan3 |
+| `:galkaika` | galkaika |  |  |
+| `:galkoku` | galkoku | `>galkokua`<br>`>hyouban` | galkokua<br>hyouban |
+| `:galmedes` | galmedes |  |  |
+| `:ganbare` | ganbare |  |  |
+| `:gangwars` | gangwars | `>gangwarsb`<br>`>gangwarsj`<br>`>gangwarsu` | gangwarsb<br>gangwarsj<br>gangwarsu |
+| `:ganryu` | ganryu |  |  |
+| `:gardia` | gardia | `>gardiaj` | gardiaj |
+| `:garou` | garou | `>garoubl`<br>`>garoup` | garoubl<br>garoup |
+| `:gaxeduel` | gaxeduel |  |  |
+| `:gberet` | gberet | `>gberetb`<br>`>rushatck` | gberetb<br>rushatck |
+| `:gekiridn` | gekiridn | `>gekiridnj` | gekiridnj |
+| `:gforce2` | gforce2 | `>gforce2j`<br>`>gforce2ja`<br>`>gforce2sd` | gforce2j<br>gforce2ja<br>gforce2sd |
+| `:gground` | gground | `>ggroundj` | ggroundj |
+| `:ghostlop` | ghostlop |  |  |
+| `:ghouls` | ghouls | `>daimakai`<br>`>daimakair`<br>`>ghoulsu` | daimakai<br>daimakair<br>ghoulsu |
+| `:gigandes` | gigandes | `>gigandesa`<br>`>gigandesj` | gigandesa<br>gigandesj |
+| `:gigawing` | gigawing | `>gigawinga`<br>`>gigawingb`<br>`>gigawingd`<br>`>gigawingh`<br>`>gigawingj`<br>`>gigawingjd` | gigawinga<br>gigawingb<br>gigawingd<br>gigawingh<br>gigawingj<br>gigawingjd |
+| `:gionbana` | gionbana |  |  |
+| `:gloc` | gloc | `>glocr360`<br>`>glocr360j`<br>`>glocu` | glocr360<br>glocr360j<br>glocu |
+| `:gng` | gng | `>gnga`<br>`>gngbl`<br>`>gngblita`<br>`>gngc`<br>`>gngprot`<br>`>gngt`<br>`>makaimur`<br>`>makaimurc`<br>`>makaimurg` | gnga<br>gngbl<br>gngblita<br>gngc<br>gngprot<br>gngt<br>makaimur<br>makaimurc<br>makaimurg |
+| `:goalx3` | goalx3 |  |  |
+| `:goldmedl` | goldmedl |  |  |
+| `:goldnaxe` | goldnaxe | `>goldnaxe1`<br>`>goldnaxe2`<br>`>goldnaxe3`<br>`>goldnaxej`<br>`>goldnaxeu` | goldnaxe1<br>goldnaxe2<br>goldnaxe3<br>goldnaxej<br>goldnaxeu |
+| `:goonies` | goonies |  |  |
+| `:gowcaizr` | gowcaizr |  |  |
+| `:gpilots` | gpilots | `>gpilotsp` | gpilotsp |
+| `:gprider` | gprider | `>gpriderj`<br>`>gpriderjs`<br>`>gpriders`<br>`>gprideru`<br>`>gpriderus` | gpriderj<br>gpriderjs<br>gpriders<br>gprideru<br>gpriderus |
+| `:grchamp` | grchamp | `>grchampa`<br>`>grchampb` | grchampa<br>grchampb |
+| `:grdforce` | grdforce |  |  |
+| `:greenber` | greenber |  |  |
+| `:groovef` | groovef |  |  |
+| `:groundfx` | groundfx |  |  |
+| `:growl` | growl | `>growla`<br>`>growlp`<br>`>growlu`<br>`>runark` | growla<br>growlp<br>growlu<br>runark |
+| `:gseeker` | gseeker | `>gseekerj`<br>`>gseekeru` | gseekerj<br>gseekeru |
+| `:gsword` | gsword | `>gsword2` | gsword2 |
+| `:gulunpa` | gulunpa |  |  |
+| `:gunblade` | gunblade |  |  |
+| `:gunbustr` | gunbustr | `>gunbustrj`<br>`>gunbustru` | gunbustrj<br>gunbustru |
+| `:gunforc2` | gunforc2 | `>geostorm`<br>`>geostorma` | geostorm<br>geostorma |
+| `:gunforce` | gunforce | `>gunforcej`<br>`>gunforceu` | gunforcej<br>gunforceu |
+| `:gunfront` | gunfront | `>gunfrontj` | gunfrontj |
+| `:gunlock` | gunlock | `>gunlocko`<br>`>rayforce`<br>`>rayforcej` | gunlocko<br>rayforce<br>rayforcej |
+| `:gunsmoke` | gunsmoke | `>gunsmokeb`<br>`>gunsmokeg`<br>`>gunsmokej`<br>`>gunsmokeu`<br>`>gunsmokeua`<br>`>gunsmokeub` | gunsmokeb<br>gunsmokeg<br>gunsmokej<br>gunsmokeu<br>gunsmokeua<br>gunsmokeub |
+| `:gururin` | gururin |  |  |
+| `:gwar` | gwar | `>gwara`<br>`>gwarab`<br>`>gwarb`<br>`>gwarj` | gwara<br>gwarab<br>gwarb<br>gwarj |
+| `:gwarrior` | gwarrior |  |  |
+| `:gyruss` | gyruss | `>gyrussb`<br>`>gyrussce`<br>`>venus` | gyrussb<br>gyrussce<br>venus |
+| `:hal21` | hal21 | `>hal21j` | hal21j |
+| `:halleysc` | halleysc | `>halleysc87`<br>`>halleyscj`<br>`>halleyscja`<br>`>halleyscjp` | halleysc87<br>halleyscj<br>halleyscja<br>halleyscjp |
+| `:hamaway` | hamaway |  |  |
+| `:hanagumi` | hanagumi |  |  |
+| `:hanamomo` | hanamomo | `>hanamomb` | hanamomb |
+| `:hanaoji` | hanaoji | `>hanaojia` | hanaojia |
+| `:hangon` | hangon | `>hangon1`<br>`>hangon2` | hangon1<br>hangon2 |
+| `:hangonjr` | hangonjr |  |  |
+| `:harddunk` | harddunk | `>harddunkj` | harddunkj |
+| `:harley` | harley | `>harleya` | harleya |
+| `:hasamu` | hasamu |  |  |
+| `:headon` | headon | `>bumba`<br>`>colision`<br>`>headon1`<br>`>headonmz`<br>`>headonn`<br>`>headons`<br>`>headonsa`<br>`>hocrash`<br>`>supcrash` | bumba<br>colision<br>headon1<br>headonmz<br>headonn<br>headons<br>headonsa<br>hocrash<br>supcrash |
+| `:headon2` | headon2 | `>car2`<br>`>headon2s`<br>`>headon2sl` | car2<br>headon2s<br>headon2sl |
+| `:headoni` | headoni |  |  |
+| `:heiankyo` | heiankyo |  |  |
+| `:helifire` | helifire | `>helifirea` | helifirea |
+| `:hharry` | hharry | `>dkgensan`<br>`>dkgensanm72`<br>`>dkgensanm82`<br>`>hharryu` | dkgensan<br>dkgensanm72<br>dkgensanm82<br>hharryu |
+| `:higemaru` | higemaru |  |  |
+| `:highsplt` | highsplt | `>highsplta`<br>`>highspltb` | highsplta<br>highspltb |
+| `:hitice` | hitice | `>hiticej`<br>`>hiticerb` | hiticej<br>hiticerb |
+| `:hnageman` | hnageman |  |  |
+| `:hnxmasev` | hnxmasev |  |  |
+| `:hogalley` | hogalley |  |  |
+| `:holo` | holo |  |  |
+| `:hook` | hook | `>hookj`<br>`>hooku` | hookj<br>hooku |
+| `:horekid` | horekid | `>boobhack`<br>`>horekidb`<br>`>horekidb2` | boobhack<br>horekidb<br>horekidb2 |
+| `:horizon` | horizon |  |  |
+| `:horshoes` | horshoes |  |  |
+| `:hotd` | hotd | `>hotdo`<br>`>hotdp` | hotdo<br>hotdp |
+| `:hotrod` | hotrod | `>hotroda`<br>`>hotrodj`<br>`>hotrodja` | hotroda<br>hotrodj<br>hotrodja |
+| `:housemn2` | housemn2 |  |  |
+| `:housemnq` | housemnq |  |  |
+| `:hpyagu98` | hpyagu98 |  |  |
+| `:hsf2` | hsf2 | `>hsf2a`<br>`>hsf2d`<br>`>hsf2j`<br>`>hsf2j1` | hsf2a<br>hsf2d<br>hsf2j<br>hsf2j1 |
+| `:hustler` | hustler | `>billiard`<br>`>hustlerb`<br>`>hustlerb2`<br>`>hustlerb4`<br>`>hustlerb5`<br>`>hustlerb6`<br>`>hustlerb7`<br>`>hustlerd`<br>`>vpool` | billiard<br>hustlerb<br>hustlerb2<br>hustlerb4<br>hustlerb5<br>hustlerb6<br>hustlerb7<br>hustlerd<br>vpool |
+| `:hvymetal` | hvymetal |  |  |
+| `:hwchamp` | hwchamp | `>hwchampa`<br>`>hwchampj` | hwchampa<br>hwchampj |
+| `:hwrace` | hwrace |  |  |
+| `:hyhoo` | hyhoo |  |  |
+| `:hyhoo2` | hyhoo2 |  |  |
+| `:hyperspt` | hyperspt | `>hpolym84`<br>`>hypersptb` | hpolym84<br>hypersptb |
+| `:iceclimb` | iceclimb | `>iceclimba` | iceclimba |
+| `:ichir` | ichir | `>ichirj`<br>`>ichirk` | ichirj<br>ichirk |
+| `:idhimitu` | idhimitu |  |  |
+| `:iemoto` | iemoto | `>iemotom`<br>`>ryuuha` | iemotom<br>ryuuha |
+| `:ikari` | ikari | `>ikaria`<br>`>ikaria2`<br>`>ikarijp`<br>`>ikarijpb`<br>`>ikarinc` | ikaria<br>ikaria2<br>ikarijp<br>ikarijpb<br>ikarinc |
+| `:ikari3` | ikari3 | `>ikari3j`<br>`>ikari3k`<br>`>ikari3u`<br>`>ikari3w` | ikari3j<br>ikari3k<br>ikari3u<br>ikari3w |
+| `:imekura` | imekura |  |  |
+| `:imgfight` | imgfight | `>imgfightj` | imgfightj |
+| `:imsorry` | imsorry | `>kimsorryj` | kimsorryj |
+| `:indy500` | indy500 | `>indy500d`<br>`>indy500to` | indy500d<br>indy500to |
+| `:insectx` | insectx | `>insectxbl`<br>`>insectxj` | insectxbl<br>insectxj |
+| `:intcup94` | intcup94 | `>intcup94a` | intcup94a |
+| `:inthunt` | inthunt | `>inthuntu`<br>`>kaiteids` | inthuntu<br>kaiteids |
+| `:introdon` | introdon |  |  |
+| `:invaders` | invaders | `>alieninv`<br>`>alieninvp2`<br>`>cosmicin`<br>`>cosmicm2`<br>`>cosmicmo`<br>`>darthvdr`<br>`>galmonst`<br>`>invader4`<br>`>invaderl`<br>`>invadernc`<br>`>invadersem`<br>`>invadrmr`<br>`>invasion`<br>`>invasiona`<br>`>invasiona2`<br>`>invasionb`<br>`>invasionrz`<br>`>invasionrza`<br>`>jspecter`<br>`>jspecter2`<br>`>searthie`<br>`>searthin`<br>`>searthina`<br>`>sicv`<br>`>sicv1`<br>`>sinvemag`<br>`>sinvemag2`<br>`>sinvzen`<br>`>sisv1`<br>`>sisv2`<br>`>sisv3`<br>`>sisv4`<br>`>sitv`<br>`>sitv1`<br>`>spaceat2`<br>`>spaceatt`<br>`>spaceatt2k`<br>`>spaceattbp`<br>`>spacecom`<br>`>spacerng`<br>`>spacewr3`<br>`>spcebttl`<br>`>spceking`<br>`>spcewarla`<br>`>spcewars`<br>`>superinv`<br>`>supinvsion`<br>`>swipeout`<br>`>tst_invd`<br>`>ultrainv` | alieninv<br>alieninvp2<br>cosmicin<br>cosmicm2<br>cosmicmo<br>darthvdr<br>galmonst<br>invader4<br>invaderl<br>invadernc<br>invadersem<br>invadrmr<br>invasion<br>invasiona<br>invasiona2<br>invasionb<br>invasionrz<br>invasionrza<br>jspecter<br>jspecter2<br>searthie<br>searthin<br>searthina<br>sicv<br>sicv1<br>sinvemag<br>sinvemag2<br>sinvzen<br>sisv1<br>sisv2<br>sisv3<br>sisv4<br>sitv<br>sitv1<br>spaceat2<br>spaceatt<br>spaceatt2k<br>spaceattbp<br>spacecom<br>spacerng<br>spacewr3<br>spcebttl<br>spceking<br>spcewarla<br>spcewars<br>superinv<br>supinvsion<br>swipeout<br>tst_invd<br>ultrainv |
+| `:invadpt2` | invadpt2 | `>invaddlx`<br>`>invadpt2a`<br>`>invadpt2br`<br>`>moonbase`<br>`>moonbasea` | invaddlx<br>invadpt2a<br>invadpt2br<br>moonbase<br>moonbasea |
+| `:invcarht` | invcarht |  |  |
+| `:invds` | invds |  |  |
+| `:invho2` | invho2 | `>invho2a` | invho2a |
+| `:invinco` | invinco |  |  |
+| `:invqix` | invqix |  |  |
+| `:ipminvad` | ipminvad | `>ipminvad1` | ipminvad1 |
+| `:ironclad` | ironclad | `>ironclado` | ironclado |
+| `:ironhors` | ironhors | `>dairesya`<br>`>farwest`<br>`>ironhorsh` | dairesya<br>farwest<br>ironhorsh |
+| `:irrmaze` | irrmaze |  |  |
+| `:itaten` | itaten |  |  |
+| `:ixion` | ixion |  |  |
+| `:jackal` | jackal | `>jackalbl`<br>`>jackalj`<br>`>topgunbl`<br>`>topgunr` | jackalbl<br>jackalj<br>topgunbl<br>topgunr |
+| `:jailbrek` | jailbrek | `>jailbrekb`<br>`>manhatan` | jailbrekb<br>manhatan |
+| `:jajamaru` | jajamaru |  |  |
+| `:janbari` | janbari | `>mjanbari` | mjanbari |
+| `:jangou` | jangou |  |  |
+| `:janshin` | janshin |  |  |
+| `:jcross` | jcross | `>jcrossa` | jcrossa |
+| `:jituroku` | jituroku |  |  |
+| `:jngolady` | jngolady |  |  |
+| `:jockeygp` | jockeygp | `>jockeygpa` | jockeygpa |
+| `:jojo` | jojo | `>jojoa`<br>`>jojoar1`<br>`>jojoar2`<br>`>jojoj`<br>`>jojojr1`<br>`>jojojr2`<br>`>jojon`<br>`>jojonr1`<br>`>jojonr2`<br>`>jojor1`<br>`>jojor2`<br>`>jojou`<br>`>jojour1`<br>`>jojour2` | jojoa<br>jojoar1<br>jojoar2<br>jojoj<br>jojojr1<br>jojojr2<br>jojon<br>jojonr1<br>jojonr2<br>jojor1<br>jojor2<br>jojou<br>jojour1<br>jojour2 |
+| `:jojoba` | jojoba | `>jojobaj`<br>`>jojobajr1`<br>`>jojoban`<br>`>jojobane`<br>`>jojobaner1`<br>`>jojobanr1`<br>`>jojobar1` | jojobaj<br>jojobajr1<br>jojoban<br>jojobane<br>jojobaner1<br>jojobanr1<br>jojobar1 |
+| `:jongbou` | jongbou |  |  |
+| `:josvolly` | josvolly |  |  |
+| `:joyfulr` | joyfulr | `>mnchmobl` | mnchmobl |
+| `:joyjoy` | joyjoy |  |  |
+| `:jpark` | jpark | `>jparkj`<br>`>jparkja`<br>`>jparkjc` | jparkj<br>jparkja<br>jparkjc |
+| `:junglek` | junglek | `>jungleby`<br>`>jungleh`<br>`>junglehbr`<br>`>junglekas`<br>`>junglekj2`<br>`>junglekj2a`<br>`>piratpet` | jungleby<br>jungleh<br>junglehbr<br>junglekas<br>junglekj2<br>junglekj2a<br>piratpet |
+| `:jungler` | jungler | `>junglero`<br>`>junglers`<br>`>savanna` | junglero<br>junglers<br>savanna |
+| `:junofrst` | junofrst | `>junofrstg` | junofrstg |
+| `:jyangoku` | jyangoku |  |  |
+| `:kabukikl` | kabukikl |  |  |
+| `:kabukiz` | kabukiz | `>kabukizj` | kabukizj |
+| `:kageki` | kageki | `>kagekih`<br>`>kagekij`<br>`>kagekiu` | kagekih<br>kagekij<br>kagekiu |
+| `:kaguya` | kaguya | `>kaguyaa` | kaguyaa |
+| `:kaguya2` | kaguya2 | `>kaguya2f` | kaguya2f |
+| `:kaiserkn` | kaiserkn | `>gblchmp`<br>`>kaiserknj` | gblchmp<br>kaiserknj |
+| `:kamikaze` | kamikaze | `>astinvad`<br>`>astinvadb`<br>`>betafrce`<br>`>kosmokil` | astinvad<br>astinvadb<br>betafrce<br>kosmokil |
+| `:kanatuen` | kanatuen | `>kyuhito` | kyuhito |
+| `:karnovr` | karnovr |  |  |
+| `:kenseim` | kenseim |  |  |
+| `:kickboy` | kickboy |  |  |
+| `:kicker` | kicker | `>shaolinb`<br>`>shaolins` | shaolinb<br>shaolins |
+| `:kicknrun` | kicknrun | `>kicknrunu`<br>`>mexico86`<br>`>mexico86a` | kicknrunu<br>mexico86<br>mexico86a |
+| `:kidniki` | kidniki | `>kidnikiu`<br>`>lithero`<br>`>yanchamr` | kidnikiu<br>lithero<br>yanchamr |
+| `:kikcubic` | kikcubic | `>kikcubicb` | kikcubicb |
+| `:kikikai` | kikikai | `>knightb`<br>`>knightba` | knightb<br>knightba |
+| `:kirameki` | kirameki |  |  |
+| `:kiwames` | kiwames |  |  |
+| `:kizuna` | kizuna |  |  |
+| `:kizuna4p` | kizuna4p |  |  |
+| `:knights` | knights | `>knightsja`<br>`>knightsjb`<br>`>knightsu` | knightsja<br>knightsjb<br>knightsu |
+| `:kod` | kod | `>kodj`<br>`>kodja`<br>`>kodr1`<br>`>kodr2`<br>`>kodu` | kodj<br>kodja<br>kodr1<br>kodr2<br>kodu |
+| `:kof2000` | kof2000 | `>kof2000n` | kof2000n |
+| `:kof2001` | kof2001 | `>ct2k3sa`<br>`>ct2k3sp`<br>`>cthd2003` | ct2k3sa<br>ct2k3sp<br>cthd2003 |
+| `:kof2002` | kof2002 | `>kf10thep`<br>`>kf2k2mp`<br>`>kf2k2mp2`<br>`>kf2k2pla`<br>`>kf2k2pls`<br>`>kf2k5uni`<br>`>kof10th`<br>`>kof2002b`<br>`>kof2k4se` | kf10thep<br>kf2k2mp<br>kf2k2mp2<br>kf2k2pla<br>kf2k2pls<br>kf2k5uni<br>kof10th<br>kof2002b<br>kof2k4se |
+| `:kof2003` | kof2003 | `>kf2k3bl`<br>`>kf2k3bla`<br>`>kf2k3pl`<br>`>kf2k3upl` | kf2k3bl<br>kf2k3bla<br>kf2k3pl<br>kf2k3upl |
+| `:kof94` | kof94 |  |  |
+| `:kof95` | kof95 | `>kof95a` | kof95a |
+| `:kof96` | kof96 |  |  |
+| `:kof97` | kof97 | `>kof97k`<br>`>kof97oro`<br>`>kof97pls`<br>`>kog` | kof97k<br>kof97oro<br>kof97pls<br>kog |
+| `:kof98` | kof98 | `>kof98a`<br>`>kof98k`<br>`>kof98ka` | kof98a<br>kof98k<br>kof98ka |
+| `:kof99` | kof99 | `>kof99e`<br>`>kof99k`<br>`>kof99ka`<br>`>kof99p` | kof99e<br>kof99k<br>kof99ka<br>kof99p |
+| `:koinomp` | koinomp |  |  |
+| `:kokoroj` | kokoroj | `>kokoroja` | kokoroja |
+| `:kokoroj2` | kokoroj2 |  |  |
+| `:konamigt` | konamigt | `>rf2` | rf2 |
+| `:korinai` | korinai | `>korinaim` | korinaim |
+| `:koshien` | koshien |  |  |
+| `:kotm` | kotm |  |  |
+| `:kotm2` | kotm2 | `>kotm2a`<br>`>kotm2p` | kotm2a<br>kotm2p |
+| `:kozure` | kozure |  |  |
+| `:kram` | kram | `>kram2`<br>`>kram3` | kram2<br>kram3 |
+| `:ksayakyu` | ksayakyu |  |  |
+| `:kungfum` | kungfum | `>spartanx` | spartanx |
+| `:kurikint` | kurikint | `>kurikinta`<br>`>kurikintj`<br>`>kurikintu`<br>`>kurikintw` | kurikinta<br>kurikintj<br>kurikintu<br>kurikintw |
+| `:lamachin` | lamachin |  |  |
+| `:landmakr` | landmakr | `>landmakrj`<br>`>landmakrp` | landmakrj<br>landmakrp |
+| `:lasso` | lasso |  |  |
+| `:lastblad` | lastblad | `>lastsold` | lastsold |
+| `:lastbld2` | lastbld2 |  |  |
+| `:lastbrnx` | lastbrnx | `>lastbrnxj`<br>`>lastbrnxu` | lastbrnxj<br>lastbrnxu |
+| `:lasthope` | lasthope |  |  |
+| `:lastsurv` | lastsurv |  |  |
+| `:lbowling` | lbowling |  |  |
+| `:ldmj1mbh` | ldmj1mbh |  |  |
+| `:ldquiz4` | ldquiz4 |  |  |
+| `:ldrun` | ldrun | `>ldruna` | ldruna |
+| `:ldrun2` | ldrun2 |  |  |
+| `:ldrun3` | ldrun3 | `>ldrun3j` | ldrun3j |
+| `:ldrun4` | ldrun4 |  |  |
+| `:legendos` | legendos |  |  |
+| `:legion` | legion | `>legionj`<br>`>legionj2`<br>`>legionjb`<br>`>legionjb2` | legionj<br>legionj2<br>legionjb<br>legionjb2 |
+| `:lemans24` | lemans24 |  |  |
+| `:lethalth` | lethalth | `>thndblst` | thndblst |
+| `:lghost` | lghost | `>lghostd`<br>`>lghostud` | lghostd<br>lghostud |
+| `:lghostj` | lghostj |  |  |
+| `:lghostu` | lghostu |  |  |
+| `:lgp` | lgp | `>lgpalt` | lgpalt |
+| `:lightbr` | lightbr | `>dungeonmo`<br>`>dungeonmu`<br>`>lightbrj` | dungeonmo<br>dungeonmu<br>lightbrj |
+| `:liquidk` | liquidk | `>liquidku`<br>`>mizubaku` | liquidku<br>mizubaku |
+| `:livegal` | livegal |  |  |
+| `:lkage` | lkage | `>lkageb`<br>`>lkagebl1`<br>`>lkagebl2`<br>`>lkagebl3`<br>`>lkagebl4` | lkageb<br>lkagebl1<br>lkagebl2<br>lkagebl3<br>lkagebl4 |
+| `:lockonph` | lockonph |  |  |
+| `:locomotn` | locomotn | `>cottong`<br>`>gutangtn`<br>`>gutangtns`<br>`>guttangt`<br>`>guttangts3`<br>`>locoboot` | cottong<br>gutangtn<br>gutangtns<br>guttangt<br>guttangts3<br>locoboot |
+| `:loffire` | loffire | `>loffirej`<br>`>loffireu` | loffirej<br>loffireu |
+| `:loht` | loht | `>lohtj` | lohtj |
+| `:lostwsga` | lostwsga | `>lostwsgp` | lostwsgp |
+| `:lotlot` | lotlot |  |  |
+| `:lrescue` | lrescue | `>desterth`<br>`>escmars`<br>`>grescue`<br>`>lrescueabl`<br>`>lrescuem`<br>`>lrescuem2`<br>`>mlander`<br>`>resclunar` | desterth<br>escmars<br>grescue<br>lrescueabl<br>lrescuem<br>lrescuem2<br>mlander<br>resclunar |
+| `:lresort` | lresort | `>lresortp` | lresortp |
+| `:lsasquad` | lsasquad | `>storming`<br>`>storminga` | storming<br>storminga |
+| `:ltswords` | ltswords | `>kengo`<br>`>kengoj` | kengo<br>kengoj |
+| `:luckygrl` | luckygrl |  |  |
+| `:lupin3` | lupin3 | `>lupin3a` | lupin3a |
+| `:lwings` | lwings | `>lwings2`<br>`>lwingsb`<br>`>lwingsj`<br>`>lwingsja` | lwings2<br>lwingsb<br>lwingsj<br>lwingsja |
+| `:macha` | macha |  |  |
+| `:madcrash` | madcrash | `>madcrush` | madcrush |
+| `:magdrop2` | magdrop2 |  |  |
+| `:magdrop3` | magdrop3 |  |  |
+| `:maglord` | maglord |  |  |
+| `:magmax` | magmax | `>magmaxa` | magmaxa |
+| `:magtruck` | magtruck |  |  |
+| `:magzun` | magzun |  |  |
+| `:mahmajn` | mahmajn |  |  |
+| `:mahmajn2` | mahmajn2 |  |  |
+| `:mahretsu` | mahretsu |  |  |
+| `:maiko` | maiko |  |  |
+| `:mainsnk` | mainsnk |  |  |
+| `:majtitl2` | majtitl2 | `>majtitl2a`<br>`>majtitl2b`<br>`>majtitl2j`<br>`>skingame`<br>`>skingame2` | majtitl2a<br>majtitl2b<br>majtitl2j<br>skingame<br>skingame2 |
+| `:majtitle` | majtitle | `>majtitlej` | majtitlej |
+| `:manxtt` | manxtt | `>manxttc`<br>`>manxttdx` | manxttc<br>manxttdx |
+| `:marinedt` | marinedt |  |  |
+| `:mariner` | mariner | `>800fath`<br>`>800fatha` | 800fath<br>800fatha |
+| `:mario` | mario | `>mariobl`<br>`>mariobla`<br>`>mariof`<br>`>marioj`<br>`>pestplce` | mariobl<br>mariobla<br>mariof<br>marioj<br>pestplce |
+| `:maruchan` | maruchan |  |  |
+| `:marukodq` | marukodq |  |  |
+| `:marvins` | marvins |  |  |
+| `:masterw` | masterw | `>masterwj`<br>`>masterwu`<br>`>yukiwo` | masterwj<br>masterwu<br>yukiwo |
+| `:matchit` | matchit | `>shisen`<br>`>sichuan2`<br>`>sichuan2a` | shisen<br>sichuan2<br>sichuan2a |
+| `:matchit2` | matchit2 | `>shisen2` | shisen2 |
+| `:matrim` | matrim | `>matrimbl` | matrimbl |
+| `:mausuke` | mausuke |  |  |
+| `:mbombrd` | mbombrd | `>mbombrdj` | mbombrdj |
+| `:mcontest` | mcontest |  |  |
+| `:mechatt` | mechatt | `>mechattj`<br>`>mechattu`<br>`>mechattu1` | mechattj<br>mechattu<br>mechattu1 |
+| `:megablst` | megablst | `>megablstj`<br>`>megablstu` | megablstj<br>megablstu |
+| `:megaman` | megaman | `>megamana`<br>`>rmancp2j`<br>`>rmancp2u`<br>`>rmancp2ur1`<br>`>rmancp2ur2`<br>`>rockmanj` | megamana<br>rmancp2j<br>rmancp2u<br>rmancp2ur1<br>rmancp2ur2<br>rockmanj |
+| `:megaman2` | megaman2 | `>megaman2a`<br>`>megaman2d`<br>`>megaman2h`<br>`>rockman2j` | megaman2a<br>megaman2d<br>megaman2h<br>rockman2j |
+| `:megazone` | megazone | `>megazonea`<br>`>megazoneb`<br>`>megazoneh`<br>`>megazonei`<br>`>megazonej` | megazonea<br>megazoneb<br>megazoneh<br>megazonei<br>megazonej |
+| `:megrescu` | megrescu |  |  |
+| `:meijinsn` | meijinsn | `>meijinsna` | meijinsna |
+| `:mercs` | mercs | `>mercsj`<br>`>mercsu`<br>`>mercsur1` | mercsj<br>mercsu<br>mercsur1 |
+| `:metalb` | metalb | `>metalbj` | metalbj |
+| `:mgion` | mgion |  |  |
+| `:mgmen89` | mgmen89 |  |  |
+| `:miexchng` | miexchng |  |  |
+| `:mightguy` | mightguy |  |  |
+| `:mikie` | mikie | `>mikiehs`<br>`>mikiej`<br>`>mikiek` | mikiehs<br>mikiej<br>mikiek |
+| `:minasan` | minasan |  |  |
+| `:minivadr` | minivadr |  |  |
+| `:missilex` | missilex |  |  |
+| `:mjcamera` | mjcamera | `>mjcameram`<br>`>mjcamerao` | mjcameram<br>mjcamerao |
+| `:mjegolf` | mjegolf |  |  |
+| `:mjfocus` | mjfocus | `>mjfocusm`<br>`>peepshow` | mjfocusm<br>peepshow |
+| `:mjgaiden` | mjgaiden |  |  |
+| `:mjgottsu` | mjgottsu | `>bakuhatu` | bakuhatu |
+| `:mjgottub` | mjgottub |  |  |
+| `:mjkoiura` | mjkoiura | `>mkoiuraa` | mkoiuraa |
+| `:mjlaman` | mjlaman |  |  |
+| `:mjleague` | mjleague |  |  |
+| `:mjlstory` | mjlstory | `>ladymakr` | ladymakr |
+| `:mjnanpas` | mjnanpas | `>mjnanpaa`<br>`>mjnanpau` | mjnanpaa<br>mjnanpau |
+| `:mjnquest` | mjnquest | `>mjnquestb` | mjnquestb |
+| `:mjsikaku` | mjsikaku | `>mjsikakb`<br>`>mjsikakc`<br>`>mjsikakd`<br>`>mmsikaku` | mjsikakb<br>mjsikakc<br>mjsikakd<br>mmsikaku |
+| `:mjuraden` | mjuraden |  |  |
+| `:mkeibaou` | mkeibaou |  |  |
+| `:mladyhtr` | mladyhtr |  |  |
+| `:mlanding` | mlanding | `>mlandingj` | mlandingj |
+| `:mmagic` | mmagic |  |  |
+| `:mmaiko` | mmaiko |  |  |
+| `:mmatrix` | mmatrix | `>mmatrixa`<br>`>mmatrixd`<br>`>mmatrixj` | mmatrixa<br>mmatrixd<br>mmatrixj |
+| `:mmehyou` | mmehyou |  |  |
+| `:mofflott` | mofflott |  |  |
+| `:monsterb` | monsterb | `>monsterb2` | monsterb2 |
+| `:moshougi` | moshougi |  |  |
+| `:motoraid` | motoraid | `>motoraiddx` | motoraiddx |
+| `:mpang` | mpang | `>mpanga`<br>`>mpangj`<br>`>mpangr1`<br>`>mpangu` | mpanga<br>mpangj<br>mpangr1<br>mpangu |
+| `:mpatrol` | mpatrol | `>mpatrolw`<br>`>mranger` | mpatrolw<br>mranger |
+| `:mpumpkin` | mpumpkin |  |  |
+| `:mrgoemon` | mrgoemon |  |  |
+| `:mrviking` | mrviking |  |  |
+| `:mscoutm` | mscoutm |  |  |
+| `:msh` | msh | `>msha`<br>`>mshb`<br>`>mshbr1`<br>`>mshh`<br>`>mshj`<br>`>mshjr1`<br>`>mshu`<br>`>mshud` | msha<br>mshb<br>mshbr1<br>mshh<br>mshj<br>mshjr1<br>mshu<br>mshud |
+| `:mshvsf` | mshvsf | `>mshvsfa`<br>`>mshvsfa1`<br>`>mshvsfb`<br>`>mshvsfb1`<br>`>mshvsfh`<br>`>mshvsfj`<br>`>mshvsfj1`<br>`>mshvsfj2`<br>`>mshvsfu`<br>`>mshvsfu1`<br>`>mshvsfu1d` | mshvsfa<br>mshvsfa1<br>mshvsfb<br>mshvsfb1<br>mshvsfh<br>mshvsfj<br>mshvsfj1<br>mshvsfj2<br>mshvsfu<br>mshvsfu1<br>mshvsfu1d |
+| `:msisaac` | msisaac |  |  |
+| `:msjiken` | msjiken |  |  |
+| `:mslug` | mslug |  |  |
+| `:mslug2` | mslug2 | `>mslug2t` | mslug2t |
+| `:mslug3` | mslug3 | `>mslug3a`<br>`>mslug3b6` | mslug3a<br>mslug3b6 |
+| `:mslug4` | mslug4 | `>ms4plus` | ms4plus |
+| `:mslug5` | mslug5 | `>ms5plus`<br>`>mslug5b` | ms5plus<br>mslug5b |
+| `:mslugx` | mslugx |  |  |
+| `:msword` | msword | `>mswordj`<br>`>mswordr1`<br>`>mswordu` | mswordj<br>mswordr1<br>mswordu |
+| `:mtwins` | mtwins | `>chikij` | chikij |
+| `:mutnat` | mutnat |  |  |
+| `:mvp` | mvp | `>mvpj` | mvpj |
+| `:mvsc` | mvsc | `>mvsca`<br>`>mvscar1`<br>`>mvscb`<br>`>mvsch`<br>`>mvscj`<br>`>mvscjr1`<br>`>mvscjsing`<br>`>mvscr1`<br>`>mvscu`<br>`>mvscud`<br>`>mvscur1` | mvsca<br>mvscar1<br>mvscb<br>mvsch<br>mvscj<br>mvscjr1<br>mvscjsing<br>mvscr1<br>mvscu<br>mvscud<br>mvscur1 |
+| `:mwalk` | mwalk | `>walkj`<br>`>walku` | walkj<br>walku |
+| `:myfairld` | myfairld |  |  |
+| `:myhero` | myhero | `>sscandal` | sscandal |
+| `:mysticri` | mysticri | `>gunhohki` | gunhohki |
+| `:nam1975` | nam1975 |  |  |
+| `:nameclub` | nameclub |  |  |
+| `:nastar` | nastar | `>nastarw`<br>`>rastsag2` | nastarw<br>rastsag2 |
+| `:nbbatman` | nbbatman | `>leaguemn`<br>`>leaguemna`<br>`>nbbatmanu` | leaguemn<br>leaguemna<br>nbbatmanu |
+| `:nclubdis` | nclubdis |  |  |
+| `:nclubv2` | nclubv2 |  |  |
+| `:nclubv3` | nclubv3 |  |  |
+| `:nclubv4` | nclubv4 |  |  |
+| `:ncombat` | ncombat |  |  |
+| `:ncommand` | ncommand |  |  |
+| `:nemesis` | nemesis | `>gradius`<br>`>gradiusuk` | gradius<br>gradiusuk |
+| `:nemo` | nemo | `>nemoj`<br>`>nemor1` | nemoj<br>nemor1 |
+| `:neobombe` | neobombe |  |  |
+| `:neocup98` | neocup98 |  |  |
+| `:neodrift` | neodrift |  |  |
+| `:neomrdo` | neomrdo |  |  |
+| `:netmerc` | netmerc |  |  |
+| `:newsin7` | newsin7 | `>newsin7a` | newsin7a |
+| `:ngalsumr` | ngalsumr |  |  |
+| `:ngpgal` | ngpgal |  |  |
+| `:ngtbunny` | ngtbunny | `>royalngt` | royalngt |
+| `:nightgal` | nightgal |  |  |
+| `:nightlov` | nightlov |  |  |
+| `:nightstr` | nightstr | `>nightstrj`<br>`>nightstru` | nightstrj<br>nightstru |
+| `:ninjakun` | ninjakun |  |  |
+| `:ninjamas` | ninjamas |  |  |
+| `:ninjaw` | ninjaw | `>ninjaw1`<br>`>ninjawj`<br>`>ninjawu` | ninjaw1<br>ninjawj<br>ninjawu |
+| `:ninjemak` | ninjemak | `>ninjemat`<br>`>youma`<br>`>youma2`<br>`>youmab`<br>`>youmab2` | ninjemat<br>youma<br>youma2<br>youmab<br>youmab2 |
+| `:nitd` | nitd | `>nitdbl` | nitdbl |
+| `:nob` | nob | `>nobb` | nobb |
+| `:nostromo` | nostromo | `>startrks` | startrks |
+| `:nspirit` | nspirit | `>nspiritj` | nspiritj |
+| `:nss_actr` | nss_actr |  |  |
+| `:nss_adam` | nss_adam |  |  |
+| `:nss_aten` | nss_aten |  |  |
+| `:nss_con3` | nss_con3 |  |  |
+| `:nss_fzer` | nss_fzer |  |  |
+| `:nss_lwep` | nss_lwep |  |  |
+| `:nss_ncaa` | nss_ncaa |  |  |
+| `:nss_rob3` | nss_rob3 |  |  |
+| `:nss_skin` | nss_skin |  |  |
+| `:nss_smas` | nss_smas |  |  |
+| `:nss_smw` | nss_smw |  |  |
+| `:nss_ssoc` | nss_ssoc |  |  |
+| `:nss_sten` | nss_sten |  |  |
+| `:nsub` | nsub | `>nsubc` | nsubc |
+| `:ntopstar` | ntopstar |  |  |
+| `:nvs_machrider` | nvs_machrider | `>nvs_machridera` | nvs_machridera |
+| `:nwarr` | nwarr | `>nwarra`<br>`>nwarrb`<br>`>nwarrh`<br>`>nwarru`<br>`>nwarrud`<br>`>vhuntj`<br>`>vhuntjr1`<br>`>vhuntjr1s`<br>`>vhuntjr2` | nwarra<br>nwarrb<br>nwarrh<br>nwarru<br>nwarrud<br>vhuntj<br>vhuntjr1<br>vhuntjr1s<br>vhuntjr2 |
+| `:oceanhun` | oceanhun | `>oceanhuna` | oceanhuna |
+| `:ohpaipee` | ohpaipee |  |  |
+| `:ojousan` | ojousan | `>ojousanm` | ojousanm |
+| `:omotesnd` | omotesnd |  |  |
+| `:opaopa` | opaopa | `>opaopan` | opaopan |
+| `:opwolf` | opwolf | `>opwolfa`<br>`>opwolfb`<br>`>opwolfj`<br>`>opwolfjsc`<br>`>opwolfp`<br>`>opwolfu` | opwolfa<br>opwolfb<br>opwolfj<br>opwolfjsc<br>opwolfp<br>opwolfu |
+| `:orangec` | orangec | `>orangeci`<br>`>vipclub` | orangeci<br>vipclub |
+| `:orunners` | orunners | `>orunnersj`<br>`>orunnersu` | orunnersj<br>orunnersu |
+| `:otatidai` | otatidai |  |  |
+| `:othellos` | othellos |  |  |
+| `:othunder` | othunder | `>othunderj`<br>`>othunderjsc`<br>`>othunderua` | othunderj<br>othunderjsc<br>othunderua |
+| `:othundero` | othundero | `>othunder` | othunder |
+| `:otonano` | otonano |  |  |
+| `:outrun` | outrun | `>outrundx`<br>`>outrundxa`<br>`>outrundxeh`<br>`>outrundxeha`<br>`>outrundxj`<br>`>outruneh`<br>`>outruneha`<br>`>outrunra` | outrundx<br>outrundxa<br>outrundxeh<br>outrundxeha<br>outrundxj<br>outruneh<br>outruneha<br>outrunra |
+| `:overrev` | overrev | `>overrevb`<br>`>overrevba` | overrevb<br>overrevba |
+| `:overtop` | overtop |  |  |
+| `:ozmawars` | ozmawars | `>ozmawars2`<br>`>ozmawarsmr`<br>`>solfight`<br>`>spaceph` | ozmawars2<br>ozmawarsmr<br>solfight<br>spaceph |
+| `:pachiten` | pachiten |  |  |
+| `:paddlema` | paddlema |  |  |
+| `:pairsnb` | pairsnb | `>pairsten` | pairsten |
+| `:palamed` | palamed | `>palamedj` | palamedj |
+| `:pandoras` | pandoras |  |  |
+| `:pang` | pang | `>bbros`<br>`>pangb`<br>`>pangb2`<br>`>pangba`<br>`>pangbb`<br>`>pangbc`<br>`>pangbold`<br>`>pangbp`<br>`>pompingw` | bbros<br>pangb<br>pangb2<br>pangba<br>pangbb<br>pangbc<br>pangbold<br>pangbp<br>pompingw |
+| `:pang3` | pang3 | `>pang3j`<br>`>pang3r1` | pang3j<br>pang3r1 |
+| `:panicbom` | panicbom |  |  |
+| `:panicr` | panicr | `>panicrg` | panicrg |
+| `:panther` | panther |  |  |
+| `:parentj` | parentj |  |  |
+| `:passsht` | passsht | `>cencourt`<br>`>passsht16a`<br>`>passshta`<br>`>passshtj` | cencourt<br>passsht16a<br>passshta<br>passshtj |
+| `:pastelg` | pastelg |  |  |
+| `:patimono` | patimono |  |  |
+| `:patocar` | patocar |  |  |
+| `:pballoon` | pballoon | `>pballoonr` | pballoonr |
+| `:pblbeach` | pblbeach |  |  |
+| `:pbobbl2n` | pbobbl2n |  |  |
+| `:pbobble` | pbobble | `>bublbust` | bublbust |
+| `:pbobble2` | pbobble2 | `>pbobble2j`<br>`>pbobble2o`<br>`>pbobble2u`<br>`>pbobble2x` | pbobble2j<br>pbobble2o<br>pbobble2u<br>pbobble2x |
+| `:pbobble3` | pbobble3 | `>pbobble3j`<br>`>pbobble3u` | pbobble3j<br>pbobble3u |
+| `:pbobble4` | pbobble4 | `>pbobble4j`<br>`>pbobble4u` | pbobble4j<br>pbobble4u |
+| `:pbobblen` | pbobblen | `>pbobblenb` | pbobblenb |
+| `:pc_1942` | pc_1942 |  |  |
+| `:pc_bball` | pc_bball |  |  |
+| `:pc_bfght` | pc_bfght |  |  |
+| `:pc_bload` | pc_bload |  |  |
+| `:pc_bstar` | pc_bstar |  |  |
+| `:pc_cntra` | pc_cntra |  |  |
+| `:pc_cshwk` | pc_cshwk |  |  |
+| `:pc_cvnia` | pc_cvnia |  |  |
+| `:pc_dbldr` | pc_dbldr |  |  |
+| `:pc_ddrgn` | pc_ddrgn |  |  |
+| `:pc_drmro` | pc_drmro | `>pc_virus` | pc_virus |
+| `:pc_duckh` | pc_duckh |  |  |
+| `:pc_ebike` | pc_ebike |  |  |
+| `:pc_ftqst` | pc_ftqst |  |  |
+| `:pc_gntlt` | pc_gntlt |  |  |
+| `:pc_golf` | pc_golf |  |  |
+| `:pc_goons` | pc_goons |  |  |
+| `:pc_grdus` | pc_grdus | `>pc_grdue` | pc_grdue |
+| `:pc_hgaly` | pc_hgaly |  |  |
+| `:pc_kngfu` | pc_kngfu |  |  |
+| `:pc_mario` | pc_mario |  |  |
+| `:pc_miket` | pc_miket |  |  |
+| `:pc_mman3` | pc_mman3 |  |  |
+| `:pc_moglf` | pc_moglf |  |  |
+| `:pc_mtoid` | pc_mtoid |  |  |
+| `:pc_ngai2` | pc_ngai2 |  |  |
+| `:pc_ngai3` | pc_ngai3 |  |  |
+| `:pc_ngaid` | pc_ngaid |  |  |
+| `:pc_pinbt` | pc_pinbt |  |  |
+| `:pc_pwbld` | pc_pwbld |  |  |
+| `:pc_pwrst` | pc_pwrst |  |  |
+| `:pc_radr2` | pc_radr2 |  |  |
+| `:pc_radrc` | pc_radrc |  |  |
+| `:pc_rcpam` | pc_rcpam |  |  |
+| `:pc_rkats` | pc_rkats |  |  |
+| `:pc_rnatk` | pc_rnatk |  |  |
+| `:pc_rrngr` | pc_rrngr |  |  |
+| `:pc_rygar` | pc_rygar |  |  |
+| `:pc_sjetm` | pc_sjetm |  |  |
+| `:pc_smb` | pc_smb |  |  |
+| `:pc_smb2` | pc_smb2 |  |  |
+| `:pc_smb3` | pc_smb3 |  |  |
+| `:pc_suprc` | pc_suprc |  |  |
+| `:pc_tbowl` | pc_tbowl |  |  |
+| `:pc_tenis` | pc_tenis |  |  |
+| `:pc_tkfld` | pc_tkfld |  |  |
+| `:pc_tmnt` | pc_tmnt |  |  |
+| `:pc_tmnt2` | pc_tmnt2 |  |  |
+| `:pc_trjan` | pc_trjan |  |  |
+| `:pc_ttoon` | pc_ttoon |  |  |
+| `:pc_vball` | pc_vball |  |  |
+| `:pc_wcup` | pc_wcup |  |  |
+| `:pc_wgnmn` | pc_wgnmn |  |  |
+| `:pc_ynoid` | pc_ynoid |  |  |
+| `:pclub2` | pclub2 |  |  |
+| `:pclubj` | pclubj |  |  |
+| `:pclubjv2` | pclubjv2 | `>pclub` | pclub |
+| `:pclubjv4` | pclubjv4 |  |  |
+| `:pclubjv5` | pclubjv5 |  |  |
+| `:pclubpok` | pclubpok |  |  |
+| `:pdrift` | pdrift | `>pdrifta`<br>`>pdrifte`<br>`>pdriftj` | pdrifta<br>pdrifte<br>pdriftj |
+| `:pdriftl` | pdriftl |  |  |
+| `:pengo` | pengo | `>pengo2`<br>`>pengo4`<br>`>pengo5` | pengo2<br>pengo4<br>pengo5 |
+| `:pgoal` | pgoal |  |  |
+| `:phoenix` | phoenix | `>avefenix`<br>`>avefenixl`<br>`>avefenixrf`<br>`>batman2`<br>`>condor`<br>`>condorn`<br>`>condorva`<br>`>falcon`<br>`>fenix`<br>`>fenixn`<br>`>griffon`<br>`>griffono`<br>`>nextfase`<br>`>phoenix2`<br>`>phoenix3`<br>`>phoenixa`<br>`>phoenixass`<br>`>phoenixb`<br>`>phoenixbl`<br>`>phoenixc`<br>`>phoenixc2`<br>`>phoenixc3`<br>`>phoenixc4`<br>`>phoenixdal`<br>`>phoenixgu`<br>`>phoenixha`<br>`>phoenixi`<br>`>phoenixj`<br>`>phoenixs`<br>`>phoenixt`<br>`>phoenxp2`<br>`>vautour`<br>`>vautourz`<br>`>vautourza` | avefenix<br>avefenixl<br>avefenixrf<br>batman2<br>condor<br>condorn<br>condorva<br>falcon<br>fenix<br>fenixn<br>griffon<br>griffono<br>nextfase<br>phoenix2<br>phoenix3<br>phoenixa<br>phoenixass<br>phoenixb<br>phoenixbl<br>phoenixc<br>phoenixc2<br>phoenixc3<br>phoenixc4<br>phoenixdal<br>phoenixgu<br>phoenixha<br>phoenixi<br>phoenixj<br>phoenixs<br>phoenixt<br>phoenxp2<br>vautour<br>vautourz<br>vautourza |
+| `:pignewt` | pignewt | `>pignewta` | pignewta |
+| `:pingpong` | pingpong |  |  |
+| `:pitfall2` | pitfall2 | `>pitfall2a`<br>`>pitfall2u` | pitfall2a<br>pitfall2u |
+| `:pitnrun` | pitnrun | `>pitnruna`<br>`>pitnrunb` | pitnruna<br>pitnrunb |
+| `:platoon` | platoon |  |  |
+| `:plgirls` | plgirls | `>lagirl` | lagirl |
+| `:plgirls2` | plgirls2 | `>plgirls2b` | plgirls2b |
+| `:plotting` | plotting | `>flipull`<br>`>plottinga`<br>`>plottingb`<br>`>plottingu` | flipull<br>plottinga<br>plottingb<br>plottingu |
+| `:pltkids` | pltkids | `>pltkidsa` | pltkidsa |
+| `:plumppop` | plumppop |  |  |
+| `:pnickj` | pnickj |  |  |
+| `:pnyaa` | pnyaa | `>pnyaaa` | pnyaaa |
+| `:pokonyan` | pokonyan |  |  |
+| `:pooyan` | pooyan | `>pootan`<br>`>pooyans` | pootan<br>pooyans |
+| `:popbounc` | popbounc |  |  |
+| `:popeye` | popeye | `>popeyeb2`<br>`>popeyeb3`<br>`>popeyebl`<br>`>popeyef`<br>`>popeyej`<br>`>popeyejo`<br>`>popeyeu` | popeyeb2<br>popeyeb3<br>popeyebl<br>popeyef<br>popeyej<br>popeyejo<br>popeyeu |
+| `:popnpop` | popnpop | `>popnpopj`<br>`>popnpopu` | popnpopj<br>popnpopu |
+| `:potopoto` | potopoto |  |  |
+| `:poundfor` | poundfor | `>poundforj`<br>`>poundforu` | poundforj<br>poundforu |
+| `:pow` | pow | `>powa`<br>`>powj` | powa<br>powj |
+| `:powsled` | powsled | `>powsledm`<br>`>powsledr` | powsledm<br>powsledr |
+| `:prehisle` | prehisle | `>gensitou`<br>`>prehisleb`<br>`>prehislek`<br>`>prehisleu` | gensitou<br>prehisleb<br>prehislek<br>prehisleu |
+| `:preisle2` | preisle2 |  |  |
+| `:prikura` | prikura |  |  |
+| `:progear` | progear | `>progeara`<br>`>progearj`<br>`>progearjbl`<br>`>progearjd`<br>`>progearud` | progeara<br>progearj<br>progearjbl<br>progearjd<br>progearud |
+| `:psailor1` | psailor1 |  |  |
+| `:psailor2` | psailor2 |  |  |
+| `:pspikes2` | pspikes2 |  |  |
+| `:pstadium` | pstadium |  |  |
+| `:psychos` | psychos | `>psychosj` | psychosj |
+| `:puchicar` | puchicar | `>puchicarj`<br>`>puchicaru` | puchicarj<br>puchicaru |
+| `:pulirula` | pulirula | `>pulirulaa`<br>`>pulirulaj` | pulirulaa<br>pulirulaj |
+| `:pulsar` | pulsar |  |  |
+| `:pulstar` | pulstar |  |  |
+| `:punchout` | punchout | `>punchita`<br>`>punchouta`<br>`>punchoutj` | punchita<br>punchouta<br>punchoutj |
+| `:punisher` | punisher | `>punisherh`<br>`>punisherj`<br>`>punisheru` | punisherh<br>punisherj<br>punisheru |
+| `:puyo` | puyo | `>puyoja`<br>`>puyojb` | puyoja<br>puyojb |
+| `:puyopuy2` | puyopuy2 |  |  |
+| `:puyosun` | puyosun |  |  |
+| `:puzzldpr` | puzzldpr |  |  |
+| `:puzzledp` | puzzledp |  |  |
+| `:puzznic` | puzznic | `>puzznica`<br>`>puzznicb`<br>`>puzznici`<br>`>puzznicj`<br>`>puzznicu` | puzznica<br>puzznicb<br>puzznici<br>puzznicj<br>puzznicu |
+| `:pwrgoal` | pwrgoal | `>hthero95`<br>`>hthero95a`<br>`>hthero95u` | hthero95<br>hthero95a<br>hthero95u |
+| `:pzloop2` | pzloop2 | `>pzloop2j`<br>`>pzloop2jd`<br>`>pzloop2jr1` | pzloop2j<br>pzloop2jd<br>pzloop2jr1 |
+| `:qad` | qad | `>qadjr` | qadjr |
+| `:qcrayon` | qcrayon |  |  |
+| `:qcrayon2` | qcrayon2 |  |  |
+| `:qgh` | qgh |  |  |
+| `:qix` | qix | `>qix2`<br>`>qixa`<br>`>qixb`<br>`>qixo` | qix2<br>qixa<br>qixb<br>qixo |
+| `:qjinsei` | qjinsei |  |  |
+| `:qmhayaku` | qmhayaku |  |  |
+| `:qndream` | qndream |  |  |
+| `:qrouka` | qrouka |  |  |
+| `:qsww` | qsww |  |  |
+| `:qtheater` | qtheater |  |  |
+| `:qtono2j` | qtono2j |  |  |
+| `:qtorimon` | qtorimon |  |  |
+| `:quartet` | quartet | `>quartet2`<br>`>quartet2a`<br>`>quarteta` | quartet2<br>quartet2a<br>quarteta |
+| `:quizdai2` | quizdai2 |  |  |
+| `:quizdais` | quizdais | `>quizdaisk` | quizdaisk |
+| `:quizf1` | quizf1 |  |  |
+| `:quizhq` | quizhq |  |  |
+| `:quizhuhu` | quizhuhu |  |  |
+| `:quizkof` | quizkof | `>quizkofk` | quizkofk |
+| `:quizmeku` | quizmeku |  |  |
+| `:qzchikyu` | qzchikyu |  |  |
+| `:qzquest` | qzquest |  |  |
+| `:qzshowby` | qzshowby |  |  |
+| `:rachero` | rachero |  |  |
+| `:racingb` | racingb | `>racingbj` | racingbj |
+| `:radarscp` | radarscp | `>radarscp1` | radarscp1 |
+| `:radm` | radm | `>radmu` | radmu |
+| `:radr` | radr | `>radrj`<br>`>radru` | radrj<br>radru |
+| `:radrad` | radrad | `>radradj` | radradj |
+| `:raflesia` | raflesia |  |  |
+| `:ragnagrd` | ragnagrd |  |  |
+| `:raimais` | raimais | `>raimaisj`<br>`>raimaisjo` | raimaisj<br>raimaisjo |
+| `:rambo3` | rambo3 | `>rambo3p`<br>`>rambo3u` | rambo3p<br>rambo3u |
+| `:rascot` | rascot |  |  |
+| `:rascot2` | rascot2 |  |  |
+| `:rastan` | rastan | `>rastana`<br>`>rastanb`<br>`>rastanu`<br>`>rastanua`<br>`>rastanub`<br>`>rastsaga`<br>`>rastsagaa`<br>`>rastsagab` | rastana<br>rastanb<br>rastanu<br>rastanua<br>rastanub<br>rastsaga<br>rastsagaa<br>rastsagab |
+| `:razmataz` | razmataz |  |  |
+| `:rbff1` | rbff1 | `>rbff1a`<br>`>rbff1k`<br>`>rbff1ka` | rbff1a<br>rbff1k<br>rbff1ka |
+| `:rbff2` | rbff2 | `>rbff2k` | rbff2k |
+| `:rbffspec` | rbffspec | `>rbffspeck` | rbffspeck |
+| `:rbisland` | rbisland | `>jumping`<br>`>jumpinga`<br>`>jumpingi`<br>`>rbislando` | jumping<br>jumpinga<br>jumpingi<br>rbislando |
+| `:rbislande` | rbislande |  |  |
+| `:rchase` | rchase | `>rchasej` | rchasej |
+| `:rchase2` | rchase2 | `>rchase2a` | rchase2a |
+| `:realpunc` | realpunc | `>realpuncj` | realpuncj |
+| `:recalh` | recalh |  |  |
+| `:recordbr` | recordbr | `>gogold` | gogold |
+| `:redalert` | redalert | `>ww3` | ww3 |
+| `:redearth` | redearth | `>redearthn`<br>`>redearthnr1`<br>`>redearthr1`<br>`>warzard`<br>`>warzardr1` | redearthn<br>redearthnr1<br>redearthr1<br>warzard<br>warzardr1 |
+| `:regulus` | regulus |  |  |
+| `:renaiclb` | renaiclb |  |  |
+| `:retofinv` | retofinv | `>retofinvb`<br>`>retofinvb1`<br>`>retofinvb2`<br>`>retofinvb3`<br>`>retofinvbv` | retofinvb<br>retofinvb1<br>retofinvb2<br>retofinvb3<br>retofinvbv |
+| `:ribbit` | ribbit | `>ribbitj` | ribbitj |
+| `:ridhero` | ridhero |  |  |
+| `:ridingf` | ridingf | `>ridingfj`<br>`>ridingfu` | ridingfj<br>ridingfu |
+| `:ridleofp` | ridleofp |  |  |
+| `:ringdest` | ringdest | `>ringdesta`<br>`>ringdestb`<br>`>ringdestd`<br>`>ringdesth`<br>`>smbomb`<br>`>smbombr1` | ringdesta<br>ringdestb<br>ringdestd<br>ringdesth<br>smbomb<br>smbombr1 |
+| `:ringrage` | ringrage | `>ringragej`<br>`>ringrageu` | ringragej<br>ringrageu |
+| `:riotcity` | riotcity |  |  |
+| `:riskchal` | riskchal | `>gussun` | gussun |
+| `:rjammer` | rjammer |  |  |
+| `:roadf` | roadf | `>roadf2`<br>`>roadfh`<br>`>roadfu` | roadf2<br>roadfh<br>roadfu |
+| `:roboarmy` | roboarmy | `>roboarmya` | roboarmya |
+| `:robowres` | robowres |  |  |
+| `:rockclim` | rockclim |  |  |
+| `:rockrage` | rockrage | `>rockragea`<br>`>rockragej` | rockragea<br>rockragej |
+| `:rocnrope` | rocnrope | `>rocnropek`<br>`>ropeman` | rocnropek<br>ropeman |
+| `:rollingc` | rollingc |  |  |
+| `:rotd` | rotd |  |  |
+| `:roughrac` | roughrac |  |  |
+| `:royalqn` | royalqn |  |  |
+| `:roylcrdn` | roylcrdn | `>roylcrdna` | roylcrdna |
+| `:rsgun` | rsgun |  |  |
+| `:rtype` | rtype | `>rtypej`<br>`>rtypejp`<br>`>rtypeu` | rtypej<br>rtypejp<br>rtypeu |
+| `:rtype2` | rtype2 | `>rtype2j`<br>`>rtype2jc` | rtype2j<br>rtype2jc |
+| `:rtypeleo` | rtypeleo | `>rtypeleoj` | rtypeleoj |
+| `:ryujin` | ryujin | `>ryujina` | ryujina |
+| `:ryukyu` | ryukyu | `>ryukyua` | ryukyua |
+| `:s1945p` | s1945p |  |  |
+| `:safari` | safari | `>safaria` | safaria |
+| `:safarir` | safarir | `>safarirj` | safarirj |
+| `:sailorws` | sailorws | `>sailorwa`<br>`>sailorwr` | sailorwa<br>sailorwr |
+| `:salamand` | salamand | `>lifefrce`<br>`>lifefrcej`<br>`>salamandj`<br>`>salamandt` | lifefrce<br>lifefrcej<br>salamandj<br>salamandt |
+| `:samsh5sp` | samsh5sp |  |  |
+| `:samsho` | samsho |  |  |
+| `:samsho2` | samsho2 | `>samsho2k` | samsho2k |
+| `:samsho3` | samsho3 | `>fswords` | fswords |
+| `:samsho4` | samsho4 | `>samsho4k` | samsho4k |
+| `:samsho5` | samsho5 | `>samsho5a`<br>`>samsho5b` | samsho5a<br>samsho5b |
+| `:samurai` | samurai | `>samuraij` | samuraij |
+| `:sandor` | sandor | `>thunt`<br>`>thuntk` | thunt<br>thuntk |
+| `:sasissu` | sasissu | `>sanjeon` | sanjeon |
+| `:sasuke` | sasuke |  |  |
+| `:satansat` | satansat | `>satansata`<br>`>satansatind` | satansata<br>satansatind |
+| `:savagere` | savagere |  |  |
+| `:sbasebal` | sbasebal | `>sbasebalj` | sbasebalj |
+| `:sbasketb` | sbasketb | `>sbaskete`<br>`>sbasketg`<br>`>sbasketh` | sbaskete<br>sbasketg<br>sbasketh |
+| `:sbm` | sbm | `>sbmj` | sbmj |
+| `:sbp` | sbp |  |  |
+| `:scandal` | scandal | `>scandalm` | scandalm |
+| `:scessjoe` | scessjoe | `>ashnojoe` | ashnojoe |
+| `:scfinals` | scfinals | `>scfinalso` | scfinalso |
+| `:schamp` | schamp | `>sfight` | sfight |
+| `:schaser` | schaser | `>crashrd`<br>`>schasera`<br>`>schaserb`<br>`>schaserc`<br>`>schasercv`<br>`>schaserm` | crashrd<br>schasera<br>schaserb<br>schaserc<br>schasercv<br>schaserm |
+| `:sci` | sci | `>scia`<br>`>scij`<br>`>scin`<br>`>sciu` | scia<br>scij<br>scin<br>sciu |
+| `:scobra` | scobra | `>scobrab`<br>`>scobrae`<br>`>scobrae2`<br>`>scobrag`<br>`>scobraggi`<br>`>scobras`<br>`>scobrase`<br>`>suprheli` | scobrab<br>scobrae<br>scobrae2<br>scobrag<br>scobraggi<br>scobras<br>scobrase<br>suprheli |
+| `:scotrsht` | scotrsht |  |  |
+| `:scramble` | scramble | `>astroamb`<br>`>bomber`<br>`>explorer`<br>`>kamikazesp`<br>`>ncentury`<br>`>offensiv`<br>`>scrabbleo`<br>`>scramb2`<br>`>scramb3`<br>`>scramblb`<br>`>scramblebb`<br>`>scramblebf`<br>`>scramblebun`<br>`>scrambleo`<br>`>scrambler`<br>`>scrambles`<br>`>scrambles2`<br>`>scrambp`<br>`>scramce`<br>`>scrammr`<br>`>scrampt`<br>`>scramrf`<br>`>seainv`<br>`>spcmission`<br>`>spctrek`<br>`>strfbomb` | astroamb<br>bomber<br>explorer<br>kamikazesp<br>ncentury<br>offensiv<br>scrabbleo<br>scramb2<br>scramb3<br>scramblb<br>scramblebb<br>scramblebf<br>scramblebun<br>scrambleo<br>scrambler<br>scrambles<br>scrambles2<br>scrambp<br>scramce<br>scrammr<br>scrampt<br>scramrf<br>seainv<br>spcmission<br>spctrek<br>strfbomb |
+| `:scross` | scross | `>scrossa`<br>`>scrossu` | scrossa<br>scrossu |
+| `:scud` | scud | `>scudau`<br>`>scuddx`<br>`>scuddxo`<br>`>scudplus`<br>`>scudplusa` | scudau<br>scuddx<br>scuddxo<br>scudplus<br>scudplusa |
+| `:scyclone` | scyclone |  |  |
+| `:sdi` | sdi | `>defense`<br>`>sdia`<br>`>sdib` | defense<br>sdia<br>sdib |
+| `:sdodgeb` | sdodgeb |  |  |
+| `:sdungeon` | sdungeon | `>sdungeona` | sdungeona |
+| `:seabass` | seabass |  |  |
+| `:searchar` | searchar | `>searcharj`<br>`>searcharu` | searcharj<br>searcharu |
+| `:secolove` | secolove |  |  |
+| `:sectionz` | sectionz | `>sectionza` | sectionza |
+| `:seganinj` | seganinj | `>nprincess` | nprincess |
+| `:segawski` | segawski |  |  |
+| `:seicross` | seicross | `>sectrzon`<br>`>sectrzona`<br>`>sectrzont`<br>`>seicrossa` | sectrzon<br>sectrzona<br>sectrzont<br>seicrossa |
+| `:seiha` | seiha | `>seiham` | seiham |
+| `:selfeena` | selfeena |  |  |
+| `:sengoku` | sengoku |  |  |
+| `:sengoku2` | sengoku2 |  |  |
+| `:sengoku3` | sengoku3 |  |  |
+| `:sexygal` | sexygal | `>sweetgal` | sweetgal |
+| `:sf` | sf | `>sfan`<br>`>sfj`<br>`>sfjan`<br>`>sfjbl`<br>`>sfp`<br>`>sfua`<br>`>sfw` | sfan<br>sfj<br>sfjan<br>sfjbl<br>sfp<br>sfua<br>sfw |
+| `:sf2` | sf2 | `>sf2ea`<br>`>sf2eb`<br>`>sf2ed`<br>`>sf2em`<br>`>sf2en`<br>`>sf2j`<br>`>sf2j17`<br>`>sf2ja`<br>`>sf2jc`<br>`>sf2jf`<br>`>sf2jh`<br>`>sf2jl`<br>`>sf2ua`<br>`>sf2ub`<br>`>sf2uc`<br>`>sf2ud`<br>`>sf2uf`<br>`>sf2ug`<br>`>sf2uh`<br>`>sf2ui`<br>`>sf2uk` | sf2ea<br>sf2eb<br>sf2ed<br>sf2em<br>sf2en<br>sf2j<br>sf2j17<br>sf2ja<br>sf2jc<br>sf2jf<br>sf2jh<br>sf2jl<br>sf2ua<br>sf2ub<br>sf2uc<br>sf2ud<br>sf2uf<br>sf2ug<br>sf2uh<br>sf2ui<br>sf2uk |
+| `:sf2ce` | sf2ce | `>sf2ceea`<br>`>sf2ceja`<br>`>sf2cejb`<br>`>sf2cejc`<br>`>sf2cet`<br>`>sf2ceua`<br>`>sf2ceub`<br>`>sf2ceuc` | sf2ceea<br>sf2ceja<br>sf2cejb<br>sf2cejc<br>sf2cet<br>sf2ceua<br>sf2ceub<br>sf2ceuc |
+| `:sf2hf` | sf2hf | `>sf2hfj`<br>`>sf2hfu` | sf2hfj<br>sf2hfu |
+| `:sfa` | sfa | `>sfad`<br>`>sfar1`<br>`>sfar2`<br>`>sfar3`<br>`>sfau`<br>`>sfza`<br>`>sfzar1`<br>`>sfzb`<br>`>sfzbr1`<br>`>sfzh`<br>`>sfzhr1`<br>`>sfzj`<br>`>sfzjr1`<br>`>sfzjr2` | sfad<br>sfar1<br>sfar2<br>sfar3<br>sfau<br>sfza<br>sfzar1<br>sfzb<br>sfzbr1<br>sfzh<br>sfzhr1<br>sfzj<br>sfzjr1<br>sfzjr2 |
+| `:sfa2` | sfa2 | `>sfa2u`<br>`>sfa2ur1`<br>`>sfz2a`<br>`>sfz2ad`<br>`>sfz2b`<br>`>sfz2br1`<br>`>sfz2h`<br>`>sfz2j`<br>`>sfz2jd`<br>`>sfz2jr1`<br>`>sfz2n` | sfa2u<br>sfa2ur1<br>sfz2a<br>sfz2ad<br>sfz2b<br>sfz2br1<br>sfz2h<br>sfz2j<br>sfz2jd<br>sfz2jr1<br>sfz2n |
+| `:sfa3` | sfa3 | `>sfa3b`<br>`>sfa3h`<br>`>sfa3hr1`<br>`>sfa3u`<br>`>sfa3ud`<br>`>sfa3ur1`<br>`>sfa3us`<br>`>sfz3a`<br>`>sfz3ar1`<br>`>sfz3j`<br>`>sfz3jr1`<br>`>sfz3jr2`<br>`>sfz3jr2d` | sfa3b<br>sfa3h<br>sfa3hr1<br>sfa3u<br>sfa3ud<br>sfa3ur1<br>sfa3us<br>sfz3a<br>sfz3ar1<br>sfz3j<br>sfz3jr1<br>sfz3jr2<br>sfz3jr2d |
+| `:sfach` | sfach |  |  |
+| `:sfiii` | sfiii | `>sfiiia`<br>`>sfiiih`<br>`>sfiiij`<br>`>sfiiin`<br>`>sfiiina`<br>`>sfiiiu` | sfiiia<br>sfiiih<br>sfiiij<br>sfiiin<br>sfiiina<br>sfiiiu |
+| `:sfiii2` | sfiii2 | `>sfiii2h`<br>`>sfiii2j`<br>`>sfiii2n` | sfiii2h<br>sfiii2j<br>sfiii2n |
+| `:sfiii3` | sfiii3 | `>sfiii3j`<br>`>sfiii3jr1`<br>`>sfiii3n`<br>`>sfiii3nr1`<br>`>sfiii3r1`<br>`>sfiii3u`<br>`>sfiii3ur1` | sfiii3j<br>sfiii3jr1<br>sfiii3n<br>sfiii3nr1<br>sfiii3r1<br>sfiii3u<br>sfiii3ur1 |
+| `:sfish2` | sfish2 | `>sfish2j` | sfish2j |
+| `:sflush` | sflush |  |  |
+| `:sfz2al` | sfz2al | `>sfz2alb`<br>`>sfz2ald`<br>`>sfz2alh`<br>`>sfz2alj`<br>`>sfz2alr1` | sfz2alb<br>sfz2ald<br>sfz2alh<br>sfz2alj<br>sfz2alr1 |
+| `:sfzch` | sfzch | `>sfzbch` | sfzbch |
+| `:sgaltrop` | sgaltrop | `>sgaltropa` | sgaltropa |
+| `:sgemf` | sgemf | `>pfghtj`<br>`>sgemfa`<br>`>sgemfd`<br>`>sgemfh` | pfghtj<br>sgemfa<br>sgemfd<br>sgemfh |
+| `:sgladiat` | sgladiat |  |  |
+| `:sgmast` | sgmast | `>sgmastc`<br>`>sgmastcj` | sgmastc<br>sgmastcj |
+| `:sgt24h` | sgt24h |  |  |
+| `:shabdama` | shabdama |  |  |
+| `:shangkid` | shangkid | `>hiryuken` | hiryuken |
+| `:shangon` | shangon | `>shangon1`<br>`>shangon2`<br>`>shangon3`<br>`>shangonle`<br>`>shangonro` | shangon1<br>shangon2<br>shangon3<br>shangonle<br>shangonro |
+| `:shanhigw` | shanhigw |  |  |
+| `:sharrier` | sharrier | `>sharrier1` | sharrier1 |
+| `:shdancer` | shdancer | `>shdancer1`<br>`>shdancerj` | shdancer1<br>shdancerj |
+| `:sheriff` | sheriff | `>bandido`<br>`>westgun2` | bandido<br>westgun2 |
+| `:shienryu` | shienryu |  |  |
+| `:shinobi` | shinobi | `>shinobi1`<br>`>shinobi2`<br>`>shinobi3`<br>`>shinobi4`<br>`>shinobi5`<br>`>shinobi6` | shinobi1<br>shinobi2<br>shinobi3<br>shinobi4<br>shinobi5<br>shinobi6 |
+| `:shocktr2` | shocktr2 | `>lans2004` | lans2004 |
+| `:shocktro` | shocktro | `>shocktroa` | shocktroa |
+| `:shtrider` | shtrider | `>shtridera` | shtridera |
+| `:sidearms` | sidearms | `>sidearmsj`<br>`>sidearmsu`<br>`>sidearmsur1` | sidearmsj<br>sidearmsu<br>sidearmsur1 |
+| `:silentd` | silentd | `>silentdj`<br>`>silentdu` | silentdj<br>silentdu |
+| `:sindbadm` | sindbadm |  |  |
+| `:sjryuko` | sjryuko | `>sjryuko1` | sjryuko1 |
+| `:skichamp` | skichamp |  |  |
+| `:skisuprg` | skisuprg |  |  |
+| `:skyadvnt` | skyadvnt | `>skyadvntj`<br>`>skyadvntu` | skyadvntj<br>skyadvntu |
+| `:skychut` | skychut |  |  |
+| `:skyrobo` | skyrobo | `>bigfghtr`<br>`>skyrobobl` | bigfghtr<br>skyrobobl |
+| `:skyskipr` | skyskipr |  |  |
+| `:skysoldr` | skysoldr | `>skysoldrbl` | skysoldrbl |
+| `:skytargt` | skytargt |  |  |
+| `:slammast` | slammast | `>mbomberj`<br>`>slammastu` | mbomberj<br>slammastu |
+| `:slapshtr` | slapshtr |  |  |
+| `:slipstrm` | slipstrm | `>slipstrmh` | slipstrmh |
+| `:smgolf` | smgolf | `>ladygolf`<br>`>ladygolfe`<br>`>smgolfb`<br>`>smgolfj` | ladygolf<br>ladygolfe<br>smgolfb<br>smgolfj |
+| `:smgp` | smgp | `>smgpj`<br>`>smgpja` | smgpj<br>smgpja |
+| `:smleague` | smleague | `>finlarch` | finlarch |
+| `:snapper` | snapper |  |  |
+| `:socbrawl` | socbrawl |  |  |
+| `:sokyugrt` | sokyugrt |  |  |
+| `:solfigtr` | solfigtr |  |  |
+| `:sonic` | sonic | `>sonicp` | sonicp |
+| `:sonicbom` | sonicbom |  |  |
+| `:soniccar` | soniccar |  |  |
+| `:sonicfgt` | sonicfgt | `>sonicfgtj` | sonicfgtj |
+| `:sonicpop` | sonicpop |  |  |
+| `:sonicwi2` | sonicwi2 |  |  |
+| `:sonicwi3` | sonicwi3 |  |  |
+| `:sonson` | sonson | `>sonsonj` | sonsonj |
+| `:spacbeam` | spacbeam |  |  |
+| `:spacecr` | spacecr |  |  |
+| `:spacedx` | spacedx | `>spacedxj`<br>`>spacedxo`<br>`>spcinvdj` | spacedxj<br>spacedxo<br>spcinvdj |
+| `:spacefb` | spacefb | `>redbird`<br>`>spacebrd`<br>`>spacedem`<br>`>spacefba`<br>`>spacefbe`<br>`>spacefbe2`<br>`>spacefbg`<br>`>starwarr` | redbird<br>spacebrd<br>spacedem<br>spacefba<br>spacefbe<br>spacefbe2<br>spacefbg<br>starwarr |
+| `:spacefev` | spacefev | `>spacefevo`<br>`>spacefevo2` | spacefevo<br>spacefevo2 |
+| `:spacegun` | spacegun | `>spacegunj`<br>`>spacegunu` | spacegunj<br>spacegunu |
+| `:spacelnc` | spacelnc |  |  |
+| `:spaceod` | spaceod | `>spaceod2` | spaceod2 |
+| `:spaceskr` | spaceskr |  |  |
+| `:spacetrk` | spacetrk | `>spacetrkc` | spacetrkc |
+| `:spang` | spang | `>sbbros`<br>`>spangbl`<br>`>spangbl2`<br>`>spangj` | sbbros<br>spangbl<br>spangbl2<br>spangj |
+| `:spatter` | spatter | `>ssanchan` | ssanchan |
+| `:spcewarl` | spcewarl | `>intruder`<br>`>laser`<br>`>spclaser` | intruder<br>laser<br>spclaser |
+| `:spcinv95` | spcinv95 | `>akkanvdr`<br>`>spcinv95u` | akkanvdr<br>spcinv95u |
+| `:spcking2` | spcking2 |  |  |
+| `:spcpostn` | spcpostn |  |  |
+| `:spelunk2` | spelunk2 |  |  |
+| `:spelunkr` | spelunkr | `>spelunkrj` | spelunkrj |
+| `:spf2t` | spf2t | `>spf2ta`<br>`>spf2td`<br>`>spf2th`<br>`>spf2tu`<br>`>spf2xj`<br>`>spf2xjd` | spf2ta<br>spf2td<br>spf2th<br>spf2tu<br>spf2xj<br>spf2xjd |
+| `:spidman` | spidman | `>spidmanj`<br>`>spidmanu` | spidmanj<br>spidmanu |
+| `:spidmanj` | spidmanj |  |  |
+| `:spikeofe` | spikeofe |  |  |
+| `:spikeout` | spikeout |  |  |
+| `:spinmast` | spinmast |  |  |
+| `:spnchout` | spnchout | `>spnchouta`<br>`>spnchoutj` | spnchouta<br>spnchoutj |
+| `:srally2` | srally2 | `>srally2dx`<br>`>srally2p`<br>`>srally2pa` | srally2dx<br>srally2p<br>srally2pa |
+| `:srallyc` | srallyc | `>srallyca`<br>`>srallycb`<br>`>srallycdx`<br>`>srallycdxa` | srallyca<br>srallycb<br>srallycdx<br>srallycdxa |
+| `:srumbler` | srumbler | `>rushcrsh`<br>`>srumbler2`<br>`>srumbler3` | rushcrsh<br>srumbler2<br>srumbler3 |
+| `:ssf2` | ssf2 | `>ssf2a`<br>`>ssf2ar1`<br>`>ssf2h`<br>`>ssf2j`<br>`>ssf2jr1`<br>`>ssf2jr2`<br>`>ssf2r1`<br>`>ssf2tb`<br>`>ssf2tba`<br>`>ssf2tbd`<br>`>ssf2tbh`<br>`>ssf2tbj`<br>`>ssf2tbj1`<br>`>ssf2tbr1`<br>`>ssf2tbu`<br>`>ssf2u`<br>`>ssf2ud` | ssf2a<br>ssf2ar1<br>ssf2h<br>ssf2j<br>ssf2jr1<br>ssf2jr2<br>ssf2r1<br>ssf2tb<br>ssf2tba<br>ssf2tbd<br>ssf2tbh<br>ssf2tbj<br>ssf2tbj1<br>ssf2tbr1<br>ssf2tbu<br>ssf2u<br>ssf2ud |
+| `:ssf2t` | ssf2t | `>ssf2ta`<br>`>ssf2tad`<br>`>ssf2th`<br>`>ssf2tu`<br>`>ssf2tur1`<br>`>ssf2xj`<br>`>ssf2xjr1`<br>`>ssf2xjr1d`<br>`>ssf2xjr1r` | ssf2ta<br>ssf2tad<br>ssf2th<br>ssf2tu<br>ssf2tur1<br>ssf2xj<br>ssf2xjr1<br>ssf2xjr1d<br>ssf2xjr1r |
+| `:ssi` | ssi | `>majest12j`<br>`>majest12u`<br>`>ssia` | majest12j<br>majest12u<br>ssia |
+| `:ssideki` | ssideki |  |  |
+| `:ssideki2` | ssideki2 |  |  |
+| `:ssideki3` | ssideki3 |  |  |
+| `:ssideki4` | ssideki4 |  |  |
+| `:ssoldier` | ssoldier | `>psoldier` | psoldier |
+| `:ssonicbr` | ssonicbr |  |  |
+| `:sspacaho` | sspacaho |  |  |
+| `:sspaceat` | sspaceat | `>sspaceat2`<br>`>sspaceat3`<br>`>sspaceatc` | sspaceat2<br>sspaceat3<br>sspaceatc |
+| `:sspirits` | sspirits | `>sspiritj`<br>`>sspirtfc` | sspiritj<br>sspirtfc |
+| `:ssrj` | ssrj |  |  |
+| `:sss` | sss |  |  |
+| `:stakwin` | stakwin | `>stakwindev` | stakwindev |
+| `:stakwin2` | stakwin2 |  |  |
+| `:starjack` | starjack | `>starjacks` | starjacks |
+| `:starlstr` | starlstr |  |  |
+| `:stcc` | stcc | `>stcca`<br>`>stccb`<br>`>stcco` | stcca<br>stccb<br>stcco |
+| `:steelwkr` | steelwkr |  |  |
+| `:stkclmns` | stkclmns | `>stkclmnsj` | stkclmnsj |
+| `:stratgyx` | stratgyx | `>stratgys`<br>`>strongx` | stratgys<br>strongx |
+| `:streetsm` | streetsm | `>streetsm1`<br>`>streetsmj`<br>`>streetsmw` | streetsm1<br>streetsmj<br>streetsmw |
+| `:stress` | stress |  |  |
+| `:strhoop` | strhoop |  |  |
+| `:strider` | strider | `>striderj`<br>`>striderjr`<br>`>striderua`<br>`>strideruc` | striderj<br>striderjr<br>striderua<br>strideruc |
+| `:strkfgtr` | strkfgtr | `>strkfgtrj` | strkfgtrj |
+| `:subroc3d` | subroc3d |  |  |
+| `:suikoenb` | suikoenb |  |  |
+| `:superchs` | superchs | `>superchsj`<br>`>superchsp`<br>`>superchsp2`<br>`>superchsu` | superchsj<br>superchsp<br>superchsp2<br>superchsu |
+| `:superman` | superman | `>supermanj`<br>`>supermanu` | supermanj<br>supermanu |
+| `:superspy` | superspy |  |  |
+| `:suprleag` | suprleag |  |  |
+| `:suprmrio` | suprmrio | `>skatekds`<br>`>suprmrioa`<br>`>suprmriob2`<br>`>suprmriobl` | skatekds<br>suprmrioa<br>suprmriob2<br>suprmriobl |
+| `:suprridr` | suprridr |  |  |
+| `:supxevs` | supxevs |  |  |
+| `:svc` | svc | `>svcboot`<br>`>svcplus`<br>`>svcplusa`<br>`>svcsplus` | svcboot<br>svcplus<br>svcplusa<br>svcsplus |
+| `:svf` | svf | `>jleague`<br>`>jleagueo`<br>`>svfo`<br>`>svs` | jleague<br>jleagueo<br>svfo<br>svs |
+| `:swa` | swa | `>swaj` | swaj |
+| `:swat` | swat |  |  |
+| `:swinggal` | swinggal |  |  |
+| `:swtrilgy` | swtrilgy | `>swtrilgya` | swtrilgya |
+| `:syvalion` | syvalion | `>syvalionp`<br>`>syvalionu`<br>`>syvalionw` | syvalionp<br>syvalionu<br>syvalionw |
+| `:szaxxon` | szaxxon |  |  |
+| `:tactcian` | tactcian | `>tactcian2` | tactcian2 |
+| `:taiwanmb` | taiwanmb |  |  |
+| `:tantr` | tantr | `>tantrkor` | tantrkor |
+| `:tcobra2` | tcobra2 | `>ktiger2`<br>`>tcobra2u` | ktiger2<br>tcobra2u |
+| `:tdfever` | tdfever | `>tdfever2`<br>`>tdfever2b`<br>`>tdfeverj` | tdfever2<br>tdfever2b<br>tdfeverj |
+| `:techbowl` | techbowl |  |  |
+| `:teddybb` | teddybb |  |  |
+| `:telmahjn` | telmahjn |  |  |
+| `:terracre` | terracre | `>terracrea`<br>`>terracren` | terracrea<br>terracren |
+| `:terraf` | terraf | `>terrafb`<br>`>terrafj`<br>`>terrafjb`<br>`>terrafu`<br>`>terrafua` | terrafb<br>terrafj<br>terrafjb<br>terrafu<br>terrafua |
+| `:tetris` | tetris | `>tetris1`<br>`>tetris1d`<br>`>tetris2`<br>`>tetris2d`<br>`>tetris3`<br>`>tetris3d`<br>`>tetrisbl`<br>`>tetrisse`<br>`>tetrist`<br>`>tetrista`<br>`>tetristh` | tetris1<br>tetris1d<br>tetris2<br>tetris2d<br>tetris3<br>tetris3d<br>tetrisbl<br>tetrisse<br>tetrist<br>tetrista<br>tetristh |
+| `:tfrceac` | tfrceac | `>tfrceacj`<br>`>tfrceacjpb` | tfrceacj<br>tfrceacjpb |
+| `:thndrbld` | thndrbld | `>thndrbld1` | thndrbld1 |
+| `:threeds` | threeds | `>galds`<br>`>threedsa` | galds<br>threedsa |
+| `:thundfox` | thundfox | `>thundfoxj`<br>`>thundfoxu` | thundfoxj<br>thundfoxu |
+| `:tigeroad` | tigeroad | `>toramich` | toramich |
+| `:timeplt` | timeplt | `>spaceplt`<br>`>spaceplta`<br>`>timeplta`<br>`>timepltc` | spaceplt<br>spaceplta<br>timeplta<br>timepltc |
+| `:timescan` | timescan | `>timescan1`<br>`>timescan3` | timescan1<br>timescan3 |
+| `:timesold` | timesold | `>btlfield`<br>`>btlfieldb`<br>`>timesold1` | btlfield<br>btlfieldb<br>timesold1 |
+| `:timetunl` | timetunl |  |  |
+| `:titlef` | titlef | `>titlefj`<br>`>titlefu` | titlefj<br>titlefu |
+| `:tkoboxng` | tkoboxng |  |  |
+| `:tnextspc` | tnextspc | `>tnextspc2`<br>`>tnextspcj` | tnextspc2<br>tnextspcj |
+| `:tnk3` | tnk3 | `>tnk3b`<br>`>tnk3j` | tnk3b<br>tnk3j |
+| `:tnzs` | tnzs | `>tnzsj`<br>`>tnzsjo`<br>`>tnzso`<br>`>tnzsoa`<br>`>tnzsop`<br>`>tnzsuo` | tnzsj<br>tnzsjo<br>tnzso<br>tnzsoa<br>tnzsop<br>tnzsuo |
+| `:togenkyo` | togenkyo |  |  |
+| `:tokio` | tokio | `>tokiob`<br>`>tokioo`<br>`>tokiou` | tokiob<br>tokioo<br>tokiou |
+| `:tokisens` | tokisens | `>tokisensa` | tokisensa |
+| `:tokyogal` | tokyogal | `>tokimbsj` | tokimbsj |
+| `:topgun` | topgun |  |  |
+| `:tophuntr` | tophuntr |  |  |
+| `:topland` | topland | `>toplandj` | toplandj |
+| `:topskatr` | topskatr | `>topskatrj`<br>`>topskatru`<br>`>topskatruo` | topskatrj<br>topskatru<br>topskatruo |
+| `:topspeed` | topspeed | `>fullthrl`<br>`>topspeedu` | fullthrl<br>topspeedu |
+| `:toryumon` | toryumon |  |  |
+| `:toutrun` | toutrun | `>toutrun1`<br>`>toutrun2`<br>`>toutrun3`<br>`>toutrunj`<br>`>toutrunj1` | toutrun1<br>toutrun2<br>toutrun3<br>toutrunj<br>toutrunj1 |
+| `:tp84` | tp84 | `>tp84a`<br>`>tp84b` | tp84a<br>tp84b |
+| `:tpgolf` | tpgolf |  |  |
+| `:trackfld` | trackfld | `>hipoly`<br>`>hyprolym`<br>`>hyprolyma`<br>`>hyprolymb`<br>`>hyprolymba`<br>`>trackfldc`<br>`>trackfldu` | hipoly<br>hyprolym<br>hyprolyma<br>hyprolymb<br>hyprolymba<br>trackfldc<br>trackfldu |
+| `:trally` | trally |  |  |
+| `:tranqgun` | tranqgun |  |  |
+| `:transfrm` | transfrm | `>astrofl` | astrofl |
+| `:travrusa` | travrusa |  |  |
+| `:travusa` | travusa | `>motorace`<br>`>mototour` | motorace<br>mototour |
+| `:triplew1` | triplew1 |  |  |
+| `:triplew2` | triplew2 |  |  |
+| `:troangel` | troangel | `>newtangl` | newtangl |
+| `:trojan` | trojan | `>trojana`<br>`>trojanb`<br>`>trojanj`<br>`>trojanjo`<br>`>trojanlt`<br>`>trojanr` | trojana<br>trojanb<br>trojanj<br>trojanjo<br>trojanlt<br>trojanr |
+| `:trstar` | trstar | `>prmtmfgt`<br>`>prmtmfgto`<br>`>trstarj`<br>`>trstaro`<br>`>trstaroj` | prmtmfgt<br>prmtmfgto<br>trstarj<br>trstaro<br>trstaroj |
+| `:tturf` | tturf | `>tturfu` | tturfu |
+| `:tubep` | tubep | `>tubepb` | tubepb |
+| `:turbo` | turbo | `>turboa`<br>`>turbob`<br>`>turbobl`<br>`>turboc`<br>`>turbod`<br>`>turboe` | turboa<br>turbob<br>turbobl<br>turboc<br>turbod<br>turboe |
+| `:turfmast` | turfmast |  |  |
+| `:turtles` | turtles | `>600`<br>`>turpin`<br>`>turpinnv`<br>`>turpins` | 600<br>turpin<br>turpinnv<br>turpins |
+| `:tutankhm` | tutankhm | `>tutankhmb`<br>`>tutankhms` | tutankhmb<br>tutankhms |
+| `:tvtcrst2` | tvtcrst2 |  |  |
+| `:twcup98` | twcup98 | `>twsoc98` | twsoc98 |
+| `:twinbee` | twinbee |  |  |
+| `:twinbeeb` | twinbeeb |  |  |
+| `:twinhawk` | twinhawk | `>daisenpu`<br>`>twinhawku` | daisenpu<br>twinhawku |
+| `:twinqix` | twinqix |  |  |
+| `:twinspri` | twinspri |  |  |
+| `:twinsqua` | twinsqua |  |  |
+| `:twsoc96` | twsoc96 |  |  |
+| `:uccops` | uccops | `>uccopsar`<br>`>uccopsaru`<br>`>uccopsj`<br>`>uccopsu` | uccopsar<br>uccopsaru<br>uccopsj<br>uccopsu |
+| `:uchuuai` | uchuuai |  |  |
+| `:ufosensi` | ufosensi | `>ufosensib` | ufosensib |
+| `:ultracin` | ultracin |  |  |
+| `:ultramhm` | ultramhm |  |  |
+| `:undrfire` | undrfire | `>undrfirej`<br>`>undrfireu` | undrfirej<br>undrfireu |
+| `:uniwars` | uniwars | `>asideral`<br>`>galemp`<br>`>gteikoku`<br>`>pajaroes`<br>`>skyraidr`<br>`>spacbat2`<br>`>spacbatt`<br>`>spacempr` | asideral<br>galemp<br>gteikoku<br>pajaroes<br>skyraidr<br>spacbat2<br>spacbatt<br>spacempr |
+| `:unsquad` | unsquad | `>area88`<br>`>area88r` | area88<br>area88r |
+| `:upndown` | upndown | `>upndownu` | upndownu |
+| `:vangrd2` | vangrd2 |  |  |
+| `:vanguard` | vanguard | `>vanguardc`<br>`>vanguardg`<br>`>vanguardj` | vanguardc<br>vanguardg<br>vanguardj |
+| `:vanilla` | vanilla | `>finalbny` | finalbny |
+| `:varth` | varth | `>varthj`<br>`>varthjr`<br>`>varthr1`<br>`>varthu` | varthj<br>varthjr<br>varthr1<br>varthu |
+| `:vcop` | vcop | `>vcopa` | vcopa |
+| `:vcop2` | vcop2 |  |  |
+| `:vf` | vf |  |  |
+| `:vf2` | vf2 | `>vf2a`<br>`>vf2b`<br>`>vf2o` | vf2a<br>vf2b<br>vf2o |
+| `:vf3` | vf3 | `>vf3a`<br>`>vf3c`<br>`>vf3tb` | vf3a<br>vf3c<br>vf3tb |
+| `:vfkids` | vfkids |  |  |
+| `:vfremix` | vfremix |  |  |
+| `:vhunt2` | vhunt2 | `>vhunt2d`<br>`>vhunt2r1` | vhunt2d<br>vhunt2r1 |
+| `:victroad` | victroad | `>dogosoke` | dogosoke |
+| `:viewpoin` | viewpoin | `>viewpoinp` | viewpoinp |
+| `:vigilant` | vigilant | `>vigilanta`<br>`>vigilantb`<br>`>vigilantc`<br>`>vigilantd`<br>`>vigilantg`<br>`>vigilanto` | vigilanta<br>vigilantb<br>vigilantc<br>vigilantd<br>vigilantg<br>vigilanto |
+| `:viofight` | viofight | `>viofightj`<br>`>viofightu` | viofightj<br>viofightu |
+| `:vliner` | vliner | `>vliner53`<br>`>vliner54`<br>`>vliner6e`<br>`>vliner7e` | vliner53<br>vliner54<br>vliner6e<br>vliner7e |
+| `:vmahjong` | vmahjong |  |  |
+| `:volfied` | volfied | `>volfiedj`<br>`>volfiedjo`<br>`>volfiedu`<br>`>volfieduo` | volfiedj<br>volfiedjo<br>volfiedu<br>volfieduo |
+| `:von` | von | `>vonj`<br>`>vonr`<br>`>vonu` | vonj<br>vonr<br>vonu |
+| `:von2` | von2 | `>von254g`<br>`>von2a`<br>`>von2o` | von254g<br>von2a<br>von2o |
+| `:vr` | vr | `>vformula` | vformula |
+| `:vs2` | vs2 | `>vs215`<br>`>vs215o` | vs215<br>vs215o |
+| `:vs298` | vs298 | `>vs29815` | vs29815 |
+| `:vs2v991` | vs2v991 | `>vs299`<br>`>vs29915`<br>`>vs29915a`<br>`>vs29915j`<br>`>vs299a`<br>`>vs299j` | vs299<br>vs29915<br>vs29915a<br>vs29915j<br>vs299a<br>vs299j |
+| `:vsav` | vsav | `>vsava`<br>`>vsavb`<br>`>vsavd`<br>`>vsavh`<br>`>vsavj`<br>`>vsavu` | vsava<br>vsavb<br>vsavd<br>vsavh<br>vsavj<br>vsavu |
+| `:vsav2` | vsav2 | `>vsav2d` | vsav2d |
+| `:vsbball` | vsbball | `>vsbballj`<br>`>vsbballja`<br>`>vsbballjb` | vsbballj<br>vsbballja<br>vsbballjb |
+| `:vsfdf` | vsfdf |  |  |
+| `:vsgongf` | vsgongf | `>ringfgt`<br>`>ringfgta` | ringfgt<br>ringfgta |
+| `:vsgradus` | vsgradus |  |  |
+| `:vsgshoe` | vsgshoe |  |  |
+| `:vsmahjng` | vsmahjng |  |  |
+| `:vspinbal` | vspinbal | `>vspinbalj` | vspinbalj |
+| `:vsskykid` | vsskykid |  |  |
+| `:vsslalom` | vsslalom |  |  |
+| `:vssoccer` | vssoccer | `>vssoccera` | vssoccera |
+| `:vstennis` | vstennis | `>vstennisa`<br>`>vstennisb` | vstennisa<br>vstennisb |
+| `:vstriker` | vstriker | `>vstrikero` | vstrikero |
+| `:vulgus` | vulgus | `>mach9`<br>`>vulgusa`<br>`>vulgusj` | mach9<br>vulgusa<br>vulgusj |
+| `:wakuwak7` | wakuwak7 |  |  |
+| `:wantsega` | wantsega |  |  |
+| `:warriorb` | warriorb |  |  |
+| `:wasafari` | wasafari |  |  |
+| `:waterski` | waterski |  |  |
+| `:waverunr` | waverunr |  |  |
+| `:wb3` | wb3 | `>wb31`<br>`>wb32`<br>`>wb33`<br>`>wb34`<br>`>wb35` | wb31<br>wb32<br>wb33<br>wb34<br>wb35 |
+| `:wbml` | wbml | `>wbmljo`<br>`>wbmlvc` | wbmljo<br>wbmlvc |
+| `:wboy` | wboy | `>wboy2`<br>`>wboy3`<br>`>wboy6`<br>`>wboysys2`<br>`>wboysys2a` | wboy2<br>wboy3<br>wboy6<br>wboysys2<br>wboysys2a |
+| `:wcatcher` | wcatcher |  |  |
+| `:wecleman` | wecleman | `>weclemana`<br>`>weclemanb`<br>`>weclemanc` | weclemana<br>weclemanb<br>weclemanc |
+| `:wgp` | wgp | `>wgp2`<br>`>wgpj`<br>`>wgpjoy`<br>`>wgpjoya`<br>`>wgpu` | wgp2<br>wgpj<br>wgpjoy<br>wgpjoya<br>wgpu |
+| `:wh1` | wh1 |  |  |
+| `:wh2` | wh2 |  |  |
+| `:wh2j` | wh2j |  |  |
+| `:whp` | whp |  |  |
+| `:willow` | willow | `>willowj`<br>`>willowu`<br>`>willowuo` | willowj<br>willowu<br>willowuo |
+| `:wilytowr` | wilytowr | `>atomboy`<br>`>atomboya` | atomboy<br>atomboya |
+| `:wingwar` | wingwar | `>wingwar360`<br>`>wingwarj`<br>`>wingwaru` | wingwar360<br>wingwarj<br>wingwaru |
+| `:winterht` | winterht |  |  |
+| `:wiping` | wiping | `>rugrats` | rugrats |
+| `:wizzquiz` | wizzquiz | `>wizzquiza` | wizzquiza |
+| `:wjammers` | wjammers |  |  |
+| `:wmatch` | wmatch |  |  |
+| `:wof` | wof | `>wofa`<br>`>wofj`<br>`>wofr1`<br>`>wofu` | wofa<br>wofj<br>wofr1<br>wofu |
+| `:wofch` | wofch |  |  |
+| `:worldwar` | worldwar |  |  |
+| `:wpksoc` | wpksoc | `>kftgoal` | kftgoal |
+| `:wrecking` | wrecking |  |  |
+| `:wrestwar` | wrestwar | `>wrestwar1`<br>`>wrestwar2` | wrestwar1<br>wrestwar2 |
+| `:wwallyj` | wwallyj | `>wwallyja`<br>`>wwallyja3p` | wwallyja<br>wwallyja3p |
+| `:wwanpanm` | wwanpanm |  |  |
+| `:wwestern` | wwestern | `>wwestern1` | wwestern1 |
+| `:wwmarine` | wwmarine |  |  |
+| `:wyvernf0` | wyvernf0 | `>wyvernf0a` | wyvernf0a |
+| `:xmcota` | xmcota | `>xmcotaa`<br>`>xmcotaar1`<br>`>xmcotaar2`<br>`>xmcotab`<br>`>xmcotah`<br>`>xmcotahr1`<br>`>xmcotaj`<br>`>xmcotaj1`<br>`>xmcotaj2`<br>`>xmcotaj3`<br>`>xmcotajr`<br>`>xmcotar1`<br>`>xmcotar1d`<br>`>xmcotau` | xmcotaa<br>xmcotaar1<br>xmcotaar2<br>xmcotab<br>xmcotah<br>xmcotahr1<br>xmcotaj<br>xmcotaj1<br>xmcotaj2<br>xmcotaj3<br>xmcotajr<br>xmcotar1<br>xmcotar1d<br>xmcotau |
+| `:xmultipl` | xmultipl | `>xmultiplm72` | xmultiplm72 |
+| `:xmvsf` | xmvsf | `>xmvsfa`<br>`>xmvsfar1`<br>`>xmvsfar2`<br>`>xmvsfar3`<br>`>xmvsfb`<br>`>xmvsfh`<br>`>xmvsfj`<br>`>xmvsfjr1`<br>`>xmvsfjr2`<br>`>xmvsfjr3`<br>`>xmvsfr1`<br>`>xmvsfu`<br>`>xmvsfu1d`<br>`>xmvsfur1`<br>`>xmvsfur2` | xmvsfa<br>xmvsfar1<br>xmvsfar2<br>xmvsfar3<br>xmvsfb<br>xmvsfh<br>xmvsfj<br>xmvsfjr1<br>xmvsfjr2<br>xmvsfjr3<br>xmvsfr1<br>xmvsfu<br>xmvsfu1d<br>xmvsfur1<br>xmvsfur2 |
+| `:yattrmnp` | yattrmnp |  |  |
+| `:yesnoj` | yesnoj |  |  |
+| `:yiear` | yiear | `>yiear2`<br>`>yieartf` | yiear2<br>yieartf |
+| `:yosimoto` | yosimoto | `>yosimotm` | yosimotm |
+| `:youjyudn` | youjyudn |  |  |
+| `:yuyugogo` | yuyugogo |  |  |
+| `:zaxxon` | zaxxon |  |  |
+| `:zedblade` | zedblade |  |  |
+| `:zerogun` | zerogun | `>zeroguna`<br>`>zerogunaj`<br>`>zerogunj` | zeroguna<br>zerogunaj<br>zerogunj |
+| `:zintrckb` | zintrckb |  |  |
+| `:znpwfv` | znpwfv | `>znpwfvt` | znpwfvt |
+| `:zookeep` | zookeep | `>zookeep2`<br>`>zookeep3`<br>`>zookeepbl` | zookeep2<br>zookeep3<br>zookeepbl |
+| `:zunkyou` | zunkyou |  |  |
+| `:zupapa` | zupapa |  |  |
 
 </details>
 

--- a/tags.yml
+++ b/tags.yml
@@ -870,7 +870,7 @@ search:
         brand: "Endorsed by company or brand"
 
 compilation:
-  description: "Compilation of previously released games"
+  description: "Compilation of previously released games ID"
   subtag:
     adamandeve:
       description: "Adam and Eve"
@@ -1448,6 +1448,5319 @@ mameparent:
 
 mamerom:
   description: "Merged MAME ROM ZIP file > MAME ROM ZIP subfile"
+  subtag:
+    005:
+      description: "005"
+      children:
+        005a: "005a"
+    10yard:
+      description: "10yard"
+      children:
+        10yard85: "10yard85"
+        10yardj: "10yardj"
+        vs10yard: "vs10yard"
+        vs10yardj: "vs10yardj"
+        vs10yardu: "vs10yardu"
+    1941:
+      description: "1941"
+      children:
+        1941j: "1941j"
+        1941r1: "1941r1"
+        1941u: "1941u"
+    1942:
+      description: "1942"
+      children:
+        1942a: "1942a"
+        1942b: "1942b"
+        1942h: "1942h"
+        1942w: "1942w"
+    1943:
+      description: "1943"
+      children:
+        1943j: "1943j"
+        1943ja: "1943ja"
+        1943jah: "1943jah"
+        1943u: "1943u"
+        1943ua: "1943ua"
+    1943kai:
+      description: "1943kai"
+    1943mii:
+      description: "1943mii"
+    1944:
+      description: "1944"
+      children:
+        1944d: "1944d"
+        1944j: "1944j"
+        1944u: "1944u"
+    19xx:
+      description: "19xx"
+      children:
+        19xxa: "19xxa"
+        19xxar1: "19xxar1"
+        19xxb: "19xxb"
+        19xxd: "19xxd"
+        19xxh: "19xxh"
+        19xxj: "19xxj"
+        19xxjr1: "19xxjr1"
+        19xxjr2: "19xxjr2"
+        19xxu: "19xxu"
+    2020bb:
+      description: "2020bb"
+      children:
+        2020bba: "2020bba"
+    2mindril:
+      description: "2mindril"
+      children:
+        2mindrila: "2mindrila"
+    3countb:
+      description: "3countb"
+    3wonders:
+      description: "3wonders"
+      children:
+        3wondersr1: "3wondersr1"
+        3wondersrh: "3wondersrh"
+        wonder3: "wonder3"
+    40love:
+      description: "40love"
+      children:
+        40lovej: "40lovej"
+    4dwarrio:
+      description: "4dwarrio"
+    abcop:
+      description: "abcop"
+      children:
+        abcopj: "abcopj"
+    abunai:
+      description: "abunai"
+    aburner2:
+      description: "aburner2"
+      children:
+        aburner: "aburner"
+        aburner2g: "aburner2g"
+    aceattac:
+      description: "aceattac"
+      children:
+        aceattaca: "aceattaca"
+    afighter:
+      description: "afighter"
+      children:
+        afightera: "afightera"
+        afighterb: "afighterb"
+        afighterc: "afighterc"
+        afighterd: "afighterd"
+        afightere: "afightere"
+        afighterf: "afighterf"
+        afighterg: "afighterg"
+        afighterh: "afighterh"
+    ainferno:
+      description: "ainferno"
+      children:
+        ainfernoj: "ainfernoj"
+        ainfernou: "ainfernou"
+    airass:
+      description: "airass"
+      children:
+        firebarr: "firebarr"
+    airduel:
+      description: "airduel"
+      children:
+        airdueljm72: "airdueljm72"
+        airduelm72: "airduelm72"
+        airduelu: "airduelu"
+    airwlkrs:
+      description: "airwlkrs"
+    ajax:
+      description: "ajax"
+      children:
+        ajaxj: "ajaxj"
+        typhoon: "typhoon"
+    alexkidd:
+      description: "alexkidd"
+      children:
+        alexkidd1: "alexkidd1"
+    alibaba:
+      description: "alibaba"
+      children:
+        alibabab: "alibabab"
+    alien3:
+      description: "alien3"
+      children:
+        alien3j: "alien3j"
+        alien3u: "alien3u"
+    aliensyn:
+      description: "aliensyn"
+      children:
+        aliensyn2: "aliensyn2"
+        aliensyn3: "aliensyn3"
+        aliensyn5: "aliensyn5"
+        aliensyn7: "aliensyn7"
+        aliensynj: "aliensynj"
+        aliensynjo: "aliensynjo"
+    alphaho:
+      description: "alphaho"
+      children:
+        alphahob: "alphahob"
+    alpham2:
+      description: "alpham2"
+      children:
+        alpham2p: "alpham2p"
+    alpine:
+      description: "alpine"
+      children:
+        alpinea: "alpinea"
+    altbeast:
+      description: "altbeast"
+      children:
+        altbeast2: "altbeast2"
+        altbeast4: "altbeast4"
+        altbeast5: "altbeast5"
+        altbeast6: "altbeast6"
+        altbeastj: "altbeastj"
+        altbeastj1: "altbeastj1"
+        altbeastj3: "altbeastj3"
+    amazon:
+      description: "amazon"
+      children:
+        amatelas: "amatelas"
+        amazont: "amazont"
+    amidar:
+      description: "amidar"
+      children:
+        amidar1: "amidar1"
+        amidarb: "amidarb"
+        amidarb2: "amidarb2"
+        amidarc: "amidarc"
+        amidaro: "amidaro"
+        amidars: "amidars"
+        amidaru: "amidaru"
+        amigo: "amigo"
+        amigo2: "amigo2"
+        mandinga: "mandinga"
+        mandingac: "mandingac"
+        mandingaeg: "mandingaeg"
+        mandingag: "mandingag"
+        mandingarf: "mandingarf"
+        mandinka: "mandinka"
+        olmandingc: "olmandingc"
+        olmandingo: "olmandingo"
+    androdun:
+      description: "androdun"
+    andromed:
+      description: "andromed"
+    angelkds:
+      description: "angelkds"
+    anpanman:
+      description: "anpanman"
+      children:
+        anpanmana: "anpanmana"
+    aodk:
+      description: "aodk"
+    aof:
+      description: "aof"
+    aof2:
+      description: "aof2"
+    aof3:
+      description: "aof3"
+      children:
+        aof3: "aof3"
+    apparel:
+      description: "apparel"
+    appoooh:
+      description: "appoooh"
+    aquajack:
+      description: "aquajack"
+      children:
+        aquajackj: "aquajackj"
+        aquajacku: "aquajacku"
+    aquastge:
+      description: "aquastge"
+    arabfgt:
+      description: "arabfgt"
+      children:
+        arabfgtj: "arabfgtj"
+        arabfgtu: "arabfgtu"
+    arabianm:
+      description: "arabianm"
+      children:
+        arabianmj: "arabianmj"
+        arabianmu: "arabianmu"
+    arescue:
+      description: "arescue"
+      children:
+        arescuej: "arescuej"
+        arescueu: "arescueu"
+    arkanoid:
+      description: "arkanoid"
+      children:
+        ark1ball: "ark1ball"
+        arkangc: "arkangc"
+        arkangc2: "arkangc2"
+        arkanoidj: "arkanoidj"
+        arkanoidja: "arkanoidja"
+        arkanoidjb: "arkanoidjb"
+        arkanoidjbl: "arkanoidjbl"
+        arkanoidjbl2: "arkanoidjbl2"
+        arkanoidu: "arkanoidu"
+        arkanoiduo: "arkanoiduo"
+        arkatayt: "arkatayt"
+        arkatayt2: "arkatayt2"
+        arkbloc2: "arkbloc2"
+        arkbloc3: "arkbloc3"
+        arkblock: "arkblock"
+        arkgcbl: "arkgcbl"
+        arkgcbla: "arkgcbla"
+        block2: "block2"
+    arknoid2:
+      description: "arknoid2"
+      children:
+        arknoid2b: "arknoid2b"
+        arknoid2j: "arknoid2j"
+        arknoid2u: "arknoid2u"
+    arkretrn:
+      description: "arkretrn"
+      children:
+        arkretrnj: "arkretrnj"
+        arkretrnu: "arkretrnu"
+    armedf:
+      description: "armedf"
+      children:
+        armedff: "armedff"
+    armwar:
+      description: "armwar"
+      children:
+        armwara: "armwara"
+        armwarar1: "armwarar1"
+        armwarb: "armwarb"
+        armward: "armward"
+        armwaru: "armwaru"
+        armwaru1: "armwaru1"
+        pgear: "pgear"
+        pgearr1: "pgearr1"
+    armwrest:
+      description: "armwrest"
+    ashura:
+      description: "ashura"
+      children:
+        ashuraj: "ashuraj"
+        ashurau: "ashurau"
+    aso:
+      description: "aso"
+      children:
+        alphamis: "alphamis"
+        arian: "arian"
+    astorm:
+      description: "astorm"
+      children:
+        astormj: "astormj"
+        astormu: "astormu"
+    astrass:
+      description: "astrass"
+    astrob:
+      description: "astrob"
+      children:
+        astrob1: "astrob1"
+        astrob2: "astrob2"
+        astrob2a: "astrob2a"
+        astrob2b: "astrob2b"
+        astrobf: "astrobf"
+        astrobg: "astrobg"
+    asuka:
+      description: "asuka"
+      children:
+        asukaj: "asukaj"
+        asukaja: "asukaja"
+    athena:
+      description: "athena"
+      children:
+        athenab: "athenab"
+        sathena: "sathena"
+    atomicp:
+      description: "atomicp"
+    aurail:
+      description: "aurail"
+      children:
+        aurail1: "aurail1"
+        aurailj: "aurailj"
+    av2mj1bb:
+      description: "av2mj1bb"
+    av2mj2rg:
+      description: "av2mj2rg"
+    avmjts:
+      description: "avmjts"
+    avmjyk:
+      description: "avmjyk"
+    avsp:
+      description: "avsp"
+      children:
+        avspa: "avspa"
+        avspd: "avspd"
+        avsph: "avsph"
+        avspj: "avspj"
+        avspu: "avspu"
+    b2b:
+      description: "b2b"
+    bakatono:
+      description: "bakatono"
+    bakubaku:
+      description: "bakubaku"
+    ballbomb:
+      description: "ballbomb"
+    ballbros:
+      description: "ballbros"
+    balonfgt:
+      description: "balonfgt"
+    bananadr:
+      description: "bananadr"
+    bangbead:
+      description: "bangbead"
+    bankp:
+      description: "bankp"
+    barline:
+      description: "barline"
+    bassdx:
+      description: "bassdx"
+      children:
+        getbass: "getbass"
+        getbassdx: "getbassdx"
+        getbassur: "getbassur"
+    batcir:
+      description: "batcir"
+      children:
+        batcira: "batcira"
+        batcird: "batcird"
+        batcirj: "batcirj"
+    batmanfr:
+      description: "batmanfr"
+    battlnts:
+      description: "battlnts"
+      children:
+        battlntsa: "battlntsa"
+        battlntsj: "battlntsj"
+    battroad:
+      description: "battroad"
+    bayroute:
+      description: "bayroute"
+      children:
+        bayroute1: "bayroute1"
+        bayroutej: "bayroutej"
+    bbmanw:
+      description: "bbmanw"
+      children:
+        bbmanwj: "bbmanwj"
+        bbmanwja: "bbmanwja"
+        bomblord: "bomblord"
+        newapunk: "newapunk"
+    bbusters:
+      description: "bbusters"
+      children:
+        bbustersj: "bbustersj"
+        bbustersja: "bbustersja"
+        bbustersu: "bbustersu"
+        bbustersua: "bbustersua"
+    bchopper:
+      description: "bchopper"
+      children:
+        mrheli: "mrheli"
+    bel:
+      description: "bel"
+    benberob:
+      description: "benberob"
+    bermudat:
+      description: "bermudat"
+      children:
+        bermudatj: "bermudatj"
+    bigevglf:
+      description: "bigevglf"
+      children:
+        bigevglfj: "bigevglfj"
+    bijokkog:
+      description: "bijokkog"
+    bijokkoy:
+      description: "bijokkoy"
+    bikkuri:
+      description: "bikkuri"
+    bioatack:
+      description: "bioatack"
+    bionicc:
+      description: "bionicc"
+      children:
+        bionicc1: "bionicc1"
+        bionicc2: "bionicc2"
+        bioniccbl: "bioniccbl"
+        bioniccbl2: "bioniccbl2"
+        topsecrt: "topsecrt"
+        topsecrt2: "topsecrt2"
+    bjourney:
+      description: "bjourney"
+    bking:
+      description: "bking"
+    bking2:
+      description: "bking2"
+    bking3:
+      description: "bking3"
+    blazstar:
+      description: "blazstar"
+    blkpnthr:
+      description: "blkpnthr"
+    blktiger:
+      description: "blktiger"
+      children:
+        blkdrgon: "blkdrgon"
+        blktigera: "blktigera"
+    block:
+      description: "block"
+      children:
+        blockj: "blockj"
+        blockr1: "blockr1"
+        blockr2: "blockr2"
+    blockfvr:
+      description: "blockfvr"
+    blockgal:
+      description: "blockgal"
+    bloxeed:
+      description: "bloxeed"
+      children:
+        bloxeedc: "bloxeedc"
+        bloxeedu: "bloxeedu"
+    bmaster:
+      description: "bmaster"
+      children:
+        crossbld: "crossbld"
+    bnglngby:
+      description: "bnglngby"
+    bnzabros:
+      description: "bnzabros"
+      children:
+        bnzabrosj: "bnzabrosj"
+    bodyslam:
+      description: "bodyslam"
+      children:
+        dumpmtmt: "dumpmtmt"
+    bonzeadv:
+      description: "bonzeadv"
+      children:
+        bonzeadvo: "bonzeadvo"
+        bonzeadvp: "bonzeadvp"
+        bonzeadvp2: "bonzeadvp2"
+        bonzeadvu: "bonzeadvu"
+        jigkmgri: "jigkmgri"
+        jigkmgria: "jigkmgria"
+    borench:
+      description: "borench"
+      children:
+        borencha: "borencha"
+        borenchj: "borenchj"
+    brain:
+      description: "brain"
+    brdrline:
+      description: "brdrline"
+      children:
+        brdrlinb: "brdrlinb"
+        brdrlinet: "brdrlinet"
+        brdrlins: "brdrlins"
+        starrkr: "starrkr"
+    breakers:
+      description: "breakers"
+    breakrev:
+      description: "breakrev"
+    brival:
+      description: "brival"
+      children:
+        brivalj: "brivalj"
+    bshark:
+      description: "bshark"
+      children:
+        bsharkj: "bsharkj"
+        bsharkjjs: "bsharkjjs"
+        bsharku: "bsharku"
+    bstars:
+      description: "bstars"
+    bstars2:
+      description: "bstars2"
+    btlecity:
+      description: "btlecity"
+    bubblem:
+      description: "bubblem"
+      children:
+        bubblemj: "bubblemj"
+        bubblemu: "bubblemu"
+    bublbob2:
+      description: "bublbob2"
+      children:
+        bublbob2e: "bublbob2e"
+        bublbob2j: "bublbob2j"
+        bublbob2o: "bublbob2o"
+        bublbob2p: "bublbob2p"
+        bublbob2u: "bublbob2u"
+        bubsymphb: "bubsymphb"
+    bublbobl:
+      description: "bublbobl"
+      children:
+        bbredux: "bbredux"
+        boblbobl: "boblbobl"
+        bub68705: "bub68705"
+        bub8749: "bub8749"
+        bublbobl1: "bublbobl1"
+        bublboblb: "bublboblb"
+        bublboblp: "bublboblp"
+        bublboblr: "bublboblr"
+        bublboblr1: "bublboblr1"
+        bublcave: "bublcave"
+        bublcave10: "bublcave10"
+        bublcave11: "bublcave11"
+        dland: "dland"
+        sboblbobl: "sboblbobl"
+        sboblbobla: "sboblbobla"
+        sboblboblb: "sboblboblb"
+        sboblboblc: "sboblboblc"
+        sboblbobld: "sboblbobld"
+        sboblboble: "sboblboble"
+        sboblboblf: "sboblboblf"
+    buckrog:
+      description: "buckrog"
+      children:
+        buckrogn: "buckrogn"
+        buckrogn2: "buckrogn2"
+        zoom909: "zoom909"
+    buggychl:
+      description: "buggychl"
+      children:
+        buggychlt: "buggychlt"
+    bullet:
+      description: "bullet"
+    bullfgt:
+      description: "bullfgt"
+      children:
+        thetogyu: "thetogyu"
+    burningf:
+      description: "burningf"
+      children:
+        burningfp: "burningfp"
+        burningfpa: "burningfpa"
+        burningfpb: "burningfpb"
+    bygone:
+      description: "bygone"
+    cachat:
+      description: "cachat"
+      children:
+        tubeit: "tubeit"
+    cadash:
+      description: "cadash"
+      children:
+        cadashf: "cadashf"
+        cadashg: "cadashg"
+        cadashgo: "cadashgo"
+        cadashi: "cadashi"
+        cadashj: "cadashj"
+        cadashj1: "cadashj1"
+        cadashjo: "cadashjo"
+        cadashs: "cadashs"
+        cadashu: "cadashu"
+        cadashu1: "cadashu1"
+    cameltry:
+      description: "cameltry"
+      children:
+        cameltrya: "cameltrya"
+        cameltryj: "cameltryj"
+    canvas:
+      description: "canvas"
+    captcomm:
+      description: "captcomm"
+      children:
+        captcommj: "captcommj"
+        captcommjr1: "captcommjr1"
+        captcommr1: "captcommr1"
+        captcommu: "captcommu"
+    carhntds:
+      description: "carhntds"
+    carnival:
+      description: "carnival"
+      children:
+        carnivalb: "carnivalb"
+        carnivalc: "carnivalc"
+        carnivalca: "carnivalca"
+        carnivalh: "carnivalh"
+        carnivalha: "carnivalha"
+        carnivalmm: "carnivalmm"
+    cavelon:
+      description: "cavelon"
+    cawing:
+      description: "cawing"
+      children:
+        cawingj: "cawingj"
+        cawingr1: "cawingr1"
+        cawingu: "cawingu"
+        cawingur1: "cawingur1"
+    cbombers:
+      description: "cbombers"
+      children:
+        cbombersj: "cbombersj"
+        cbombersp: "cbombersp"
+    cclimber:
+      description: "cclimber"
+      children:
+        ccboot: "ccboot"
+        ccboot2: "ccboot2"
+        ccbootmm: "ccbootmm"
+        ccbootmr: "ccbootmr"
+        cclimbera: "cclimbera"
+        cclimberj: "cclimberj"
+        cclimbroper: "cclimbroper"
+        cclimbrrod: "cclimbrrod"
+    cclimbr2:
+      description: "cclimbr2"
+      children:
+        cclimbr2a: "cclimbr2a"
+    chaknpop:
+      description: "chaknpop"
+    champwr:
+      description: "champwr"
+      children:
+        champwrj: "champwrj"
+        champwru: "champwru"
+    changela:
+      description: "changela"
+    chasehq:
+      description: "chasehq"
+      children:
+        chasehqj: "chasehqj"
+        chasehqju: "chasehqju"
+        chasehqu: "chasehqu"
+    chinhero:
+      description: "chinhero"
+      children:
+        chinhero2: "chinhero2"
+        chinhero3: "chinhero3"
+        chinherot: "chinherot"
+    chinmoku:
+      description: "chinmoku"
+    choko:
+      description: "choko"
+    choplift:
+      description: "choplift"
+      children:
+        chopliftu: "chopliftu"
+    chopliftu:
+      description: "chopliftu"
+      children:
+        chopliftbl: "chopliftbl"
+    chopper:
+      description: "chopper"
+      children:
+        choppera: "choppera"
+        chopperb: "chopperb"
+        legofair: "legofair"
+    chukatai:
+      description: "chukatai"
+      children:
+        chukataij: "chukataij"
+        chukataija: "chukataija"
+        chukataiu: "chukataiu"
+    circusc:
+      description: "circusc"
+      children:
+        circusc2: "circusc2"
+        circusc3: "circusc3"
+        circusc4: "circusc4"
+        circuscc: "circuscc"
+        circusce: "circusce"
+    citylove:
+      description: "citylove"
+      children:
+        mcitylov: "mcitylov"
+    ckong:
+      description: "ckong"
+      children:
+        bigkong: "bigkong"
+        bigkonggx: "bigkonggx"
+        ckongalc: "ckongalc"
+        ckongcv: "ckongcv"
+        ckongdks: "ckongdks"
+        ckongg: "ckongg"
+        ckonggx: "ckonggx"
+        ckongis: "ckongis"
+        ckongmc: "ckongmc"
+        ckongmc2: "ckongmc2"
+        ckongo: "ckongo"
+        ckongs: "ckongs"
+        dking: "dking"
+        monkeyd: "monkeyd"
+    ckongpt2:
+      description: "ckongpt2"
+      children:
+        ckongpt2b: "ckongpt2b"
+        ckongpt2b2: "ckongpt2b2"
+        ckongpt2j: "ckongpt2j"
+        ckongpt2ss: "ckongpt2ss"
+    ckongpt2a:
+      description: "ckongpt2a"
+      children:
+        ckongpt2jeu: "ckongpt2jeu"
+    cleopatr:
+      description: "cleopatr"
+      children:
+        cleopatro: "cleopatro"
+    cltchitr:
+      description: "cltchitr"
+      children:
+        cltchitrj: "cltchitrj"
+    club90s:
+      description: "club90s"
+      children:
+        club90sa: "club90sa"
+        lovehous: "lovehous"
+    cluclu:
+      description: "cluclu"
+    cmehyou:
+      description: "cmehyou"
+    cntrygrl:
+      description: "cntrygrl"
+      children:
+        cntrygrla: "cntrygrla"
+        fruitbun: "fruitbun"
+    colmns97:
+      description: "colmns97"
+    colony7:
+      description: "colony7"
+      children:
+        colony7a: "colony7a"
+    columns:
+      description: "columns"
+      children:
+        columnsj: "columnsj"
+        columnsu: "columnsu"
+    columns2:
+      description: "columns2"
+      children:
+        column2j: "column2j"
+    combh:
+      description: "combh"
+    commando:
+      description: "commando"
+      children:
+        commandob: "commandob"
+        commandob2: "commandob2"
+        commandob3: "commandob3"
+        commandoj: "commandoj"
+        commandou: "commandou"
+        commandou2: "commandou2"
+        sinvasn: "sinvasn"
+    commandw:
+      description: "commandw"
+    complexx:
+      description: "complexx"
+    congo:
+      description: "congo"
+      children:
+        congoa: "congoa"
+        tiptop: "tiptop"
+    contcirc:
+      description: "contcirc"
+      children:
+        contcircj: "contcircj"
+        contcircu: "contcircu"
+        contcircua: "contcircua"
+    coolridr:
+      description: "coolridr"
+    cop01:
+      description: "cop01"
+      children:
+        cop01a: "cop01a"
+    cosmccop:
+      description: "cosmccop"
+      children:
+        gallop: "gallop"
+        gallopm72: "gallopm72"
+    cothello:
+      description: "cothello"
+    cotton:
+      description: "cotton"
+      children:
+        cottonj: "cottonj"
+        cottonja: "cottonja"
+        cottonu: "cottonu"
+    cotton2:
+      description: "cotton2"
+    cottonbm:
+      description: "cottonbm"
+    countryc:
+      description: "countryc"
+    crbaloon:
+      description: "crbaloon"
+      children:
+        crbaloon2: "crbaloon2"
+    crimec:
+      description: "crimec"
+      children:
+        crimecj: "crimecj"
+        crimecu: "crimecu"
+    critcrsh:
+      description: "critcrsh"
+      children:
+        tatacot: "tatacot"
+    crkdown:
+      description: "crkdown"
+      children:
+        crkdownj: "crkdownj"
+        crkdownu: "crkdownu"
+    crsword:
+      description: "crsword"
+    crystal2:
+      description: "crystal2"
+    crystalg:
+      description: "crystalg"
+    csclub:
+      description: "csclub"
+      children:
+        csclub1: "csclub1"
+        csclub1d: "csclub1d"
+        cscluba: "cscluba"
+        csclubh: "csclubh"
+        csclubj: "csclubj"
+        csclubjy: "csclubjy"
+    cstlevna:
+      description: "cstlevna"
+    ctomaday:
+      description: "ctomaday"
+    cubybop:
+      description: "cubybop"
+    cupfinal:
+      description: "cupfinal"
+      children:
+        hthero93: "hthero93"
+        hthero93u: "hthero93u"
+    cworld:
+      description: "cworld"
+    cworld2j:
+      description: "cworld2j"
+      children:
+        cworld2ja: "cworld2ja"
+        cworld2jb: "cworld2jb"
+    cyberlip:
+      description: "cyberlip"
+    cybots:
+      description: "cybots"
+      children:
+        cybotsj: "cybotsj"
+        cybotsjd: "cybotsjd"
+        cybotsu: "cybotsu"
+        cybotsud: "cybotsud"
+    dacholer:
+      description: "dacholer"
+    daikaiju:
+      description: "daikaiju"
+    dakkochn:
+      description: "dakkochn"
+    danchih:
+      description: "danchih"
+    danchiq:
+      description: "danchiq"
+    dangar:
+      description: "dangar"
+      children:
+        dangara: "dangara"
+        dangarb: "dangarb"
+        dangarbt: "dangarbt"
+        dangarj: "dangarj"
+    dankuga:
+      description: "dankuga"
+    darius:
+      description: "darius"
+      children:
+        dariuse: "dariuse"
+        dariusj: "dariusj"
+        dariuso: "dariuso"
+        dariusu: "dariusu"
+    darius2:
+      description: "darius2"
+      children:
+        darius2d: "darius2d"
+        darius2do: "darius2do"
+        sagaia: "sagaia"
+    dariusg:
+      description: "dariusg"
+      children:
+        dariusgj: "dariusgj"
+        dariusgu: "dariusgu"
+    dariusgx:
+      description: "dariusgx"
+    darkedge:
+      description: "darkedge"
+      children:
+        darkedgej: "darkedgej"
+    dayto2pe:
+      description: "dayto2pe"
+    daytona:
+      description: "daytona"
+      children:
+        daytona93: "daytona93"
+        daytonam: "daytonam"
+        daytonas: "daytonas"
+        daytonase: "daytonase"
+        daytonat: "daytonat"
+        daytonata: "daytonata"
+    daytona2:
+      description: "daytona2"
+    dblaxle:
+      description: "dblaxle"
+      children:
+        dblaxleu: "dblaxleu"
+        dblaxleul: "dblaxleul"
+        pwheelsj: "pwheelsj"
+    dbreed:
+      description: "dbreed"
+      children:
+        dbreedjm72: "dbreedjm72"
+        dbreedm72: "dbreedm72"
+    dbzvrvs:
+      description: "dbzvrvs"
+    dcclub:
+      description: "dcclub"
+      children:
+        dcclubfd: "dcclubfd"
+        dcclubj: "dcclubj"
+    ddcrew:
+      description: "ddcrew"
+      children:
+        ddcrew2: "ddcrew2"
+        ddcrewj: "ddcrewj"
+        ddcrewj2: "ddcrewj2"
+        ddcrewu: "ddcrewu"
+    dddoor:
+      description: "dddoor"
+    ddribble:
+      description: "ddribble"
+      children:
+        ddribblep: "ddribblep"
+    ddsom:
+      description: "ddsom"
+      children:
+        ddsoma: "ddsoma"
+        ddsomar1: "ddsomar1"
+        ddsomb: "ddsomb"
+        ddsomh: "ddsomh"
+        ddsomj: "ddsomj"
+        ddsomjr1: "ddsomjr1"
+        ddsomjr2: "ddsomjr2"
+        ddsomr1: "ddsomr1"
+        ddsomr2: "ddsomr2"
+        ddsomr3: "ddsomr3"
+        ddsomu: "ddsomu"
+        ddsomud: "ddsomud"
+        ddsomur1: "ddsomur1"
+    ddtod:
+      description: "ddtod"
+      children:
+        ddtoda: "ddtoda"
+        ddtodar1: "ddtodar1"
+        ddtodh: "ddtodh"
+        ddtodhr1: "ddtodhr1"
+        ddtodhr2: "ddtodhr2"
+        ddtodj: "ddtodj"
+        ddtodjr1: "ddtodjr1"
+        ddtodjr2: "ddtodjr2"
+        ddtodr1: "ddtodr1"
+        ddtodu: "ddtodu"
+        ddtodur1: "ddtodur1"
+    ddux:
+      description: "ddux"
+      children:
+        ddux1: "ddux1"
+        dduxj2: "dduxj2"
+    deadconx:
+      description: "deadconx"
+      children:
+        deadconxj: "deadconxj"
+    decathlt:
+      description: "decathlt"
+      children:
+        decathlto: "decathlto"
+    demoneye:
+      description: "demoneye"
+    depthch:
+      description: "depthch"
+      children:
+        depthcho: "depthcho"
+        subhunt: "subhunt"
+    desert:
+      description: "desert"
+    desertbr:
+      description: "desertbr"
+      children:
+        desertbrj: "desertbrj"
+    dfjail:
+      description: "dfjail"
+    dicegame:
+      description: "dicegame"
+    diehard:
+      description: "diehard"
+      children:
+        dnmtdeka: "dnmtdeka"
+    digger:
+      description: "digger"
+    diggerma:
+      description: "diggerma"
+    dimahoo:
+      description: "dimahoo"
+      children:
+        dimahoou: "dimahoou"
+        dimahooud: "dimahooud"
+        gmahou: "gmahou"
+    dino:
+      description: "dino"
+      children:
+        dinoa: "dinoa"
+        dinoj: "dinoj"
+        dinou: "dinou"
+    dinorex:
+      description: "dinorex"
+      children:
+        dinorexj: "dinorexj"
+        dinorexu: "dinorexu"
+    dirtdvls:
+      description: "dirtdvls"
+      children:
+        dirtdvlsau: "dirtdvlsau"
+        dirtdvlsg: "dirtdvlsg"
+        dirtdvlsj: "dirtdvlsj"
+        dirtdvlsu: "dirtdvlsu"
+    dkong:
+      description: "dkong"
+      children:
+        dkongf: "dkongf"
+        dkonghrd: "dkonghrd"
+        dkonghs: "dkonghs"
+        dkongike: "dkongike"
+        dkongj: "dkongj"
+        dkongj1: "dkongj1"
+        dkongjo: "dkongjo"
+        dkongjrc: "dkongjrc"
+        dkongo: "dkongo"
+        dkongpe: "dkongpe"
+        dkongx: "dkongx"
+        dkongx11: "dkongx11"
+    dkong3:
+      description: "dkong3"
+      children:
+        dkong3abl: "dkong3abl"
+        dkong3b: "dkong3b"
+        dkong3hs: "dkong3hs"
+        dkong3j: "dkong3j"
+    dkongjr:
+      description: "dkongjr"
+      children:
+        dkingjr: "dkingjr"
+        dkingjrv: "dkingjrv"
+        dkongddk: "dkongddk"
+        dkongjnrj: "dkongjnrj"
+        dkongjr2: "dkongjr2"
+        dkongjrb: "dkongjrb"
+        dkongjre: "dkongjre"
+        dkongjrhs: "dkongjrhs"
+        dkongjrj: "dkongjrj"
+        dkongjrm: "dkongjrm"
+        dkongjrmc: "dkongjrmc"
+        dkongjrpb: "dkongjrpb"
+        jrking: "jrking"
+        maguila: "maguila"
+    dleague:
+      description: "dleague"
+      children:
+        dleaguej: "dleaguej"
+    doa:
+      description: "doa"
+      children:
+        doaa: "doaa"
+        doaae: "doaae"
+        doab: "doab"
+    dockman:
+      description: "dockman"
+      children:
+        dockmanb: "dockmanb"
+        dockmanc: "dockmanc"
+        porter: "porter"
+        portera: "portera"
+        portman: "portman"
+        portmanj: "portmanj"
+        theportr: "theportr"
+    dokaben:
+      description: "dokaben"
+    dondokod:
+      description: "dondokod"
+      children:
+        dondokodj: "dondokodj"
+        dondokodu: "dondokodu"
+    dotrikun:
+      description: "dotrikun"
+      children:
+        dotrikun2: "dotrikun2"
+    doubledr:
+      description: "doubledr"
+    dragonsh:
+      description: "dragonsh"
+    driftout:
+      description: "driftout"
+      children:
+        driftoutct: "driftoutct"
+        driftoutj: "driftoutj"
+        driveout: "driveout"
+    drmario:
+      description: "drmario"
+    drtoppel:
+      description: "drtoppel"
+      children:
+        drtoppelj: "drtoppelj"
+        drtoppelu: "drtoppelu"
+    dsoccr94:
+      description: "dsoccr94"
+      children:
+        dsoccr94j: "dsoccr94j"
+        dsoccr94k: "dsoccr94k"
+    dstlk:
+      description: "dstlk"
+      children:
+        dstlka: "dstlka"
+        dstlkh: "dstlkh"
+        dstlku: "dstlku"
+        dstlku1d: "dstlku1d"
+        dstlkur1: "dstlkur1"
+        vampj: "vampj"
+        vampja: "vampja"
+        vampjr1: "vampjr1"
+    duckhunt:
+      description: "duckhunt"
+    dunkshot:
+      description: "dunkshot"
+      children:
+        dunkshota: "dunkshota"
+        dunkshoto: "dunkshoto"
+    dynabb:
+      description: "dynabb"
+    dynabb97:
+      description: "dynabb97"
+    dynablst:
+      description: "dynablst"
+      children:
+        atompunk: "atompunk"
+        bombrman: "bombrman"
+    dynamcop:
+      description: "dynamcop"
+      children:
+        dynamcopb: "dynamcopb"
+        dynamcopc: "dynamcopc"
+        dyndeka2: "dyndeka2"
+        dyndeka2b: "dyndeka2b"
+    dynamski:
+      description: "dynamski"
+    dynwar:
+      description: "dynwar"
+      children:
+        dynwara: "dynwara"
+        dynwarj: "dynwarj"
+        dynwarjr: "dynwarjr"
+    earthjkr:
+      description: "earthjkr"
+      children:
+        earthjkra: "earthjkra"
+        earthjkrb: "earthjkrb"
+        earthjkrp: "earthjkrp"
+    eca:
+      description: "eca"
+      children:
+        ecaj: "ecaj"
+        ecap: "ecap"
+        ecau: "ecau"
+    ecofghtr:
+      description: "ecofghtr"
+      children:
+        ecofghtra: "ecofghtra"
+        ecofghtrd: "ecofghtrd"
+        ecofghtrh: "ecofghtrh"
+        ecofghtru: "ecofghtru"
+        ecofghtru1: "ecofghtru1"
+        uecology: "uecology"
+    eightman:
+      description: "eightman"
+    ejihon:
+      description: "ejihon"
+    elandore:
+      description: "elandore"
+    elecyoyo:
+      description: "elecyoyo"
+      children:
+        elecyoyoa: "elecyoyoa"
+    elevator:
+      description: "elevator"
+      children:
+        elevatora: "elevatora"
+        elevatorb: "elevatorb"
+    elvactr:
+      description: "elvactr"
+      children:
+        elvactrj: "elvactrj"
+        elvactru: "elvactru"
+    enduror:
+      description: "enduror"
+      children:
+        enduror1: "enduror1"
+        endurora: "endurora"
+        endurorb: "endurorb"
+    enforce:
+      description: "enforce"
+      children:
+        enforcej: "enforcej"
+        enforceja: "enforceja"
+    eswat:
+      description: "eswat"
+      children:
+        eswatj: "eswatj"
+        eswatj1: "eswatj1"
+        eswatu: "eswatu"
+    eto:
+      description: "eto"
+      children:
+        etoa: "etoa"
+    euroch92:
+      description: "euroch92"
+      children:
+        euroch92j: "euroch92j"
+    excitebk:
+      description: "excitebk"
+      children:
+        excitebkj: "excitebkj"
+        excitebko: "excitebko"
+    exctleag:
+      description: "exctleag"
+    exedexes:
+      description: "exedexes"
+      children:
+        savgbees: "savgbees"
+    extrmatn:
+      description: "extrmatn"
+      children:
+        extrmatnj: "extrmatnj"
+        extrmatnu: "extrmatnu"
+        extrmatnur: "extrmatnur"
+    exzisus:
+      description: "exzisus"
+      children:
+        exzisusa: "exzisusa"
+        exzisust: "exzisust"
+    f1dream:
+      description: "f1dream"
+    f1en:
+      description: "f1en"
+      children:
+        f1enj: "f1enj"
+        f1enu: "f1enu"
+    f1lap:
+      description: "f1lap"
+      children:
+        f1lapj: "f1lapj"
+        f1lapt: "f1lapt"
+    fantasyu:
+      description: "fantasyu"
+      children:
+        fantasyg: "fantasyg"
+        fantasyg2: "fantasyg2"
+        fantasyj: "fantasyj"
+    fantzn2:
+      description: "fantzn2"
+    fantzn2x:
+      description: "fantzn2x"
+      children:
+        fantzn2xp: "fantzn2xp"
+    fantzone:
+      description: "fantzone"
+      children:
+        fantzone1: "fantzone1"
+        fantzonee: "fantzonee"
+        fantzonep: "fantzonep"
+        fantzonepr: "fantzonepr"
+    fanzonem:
+      description: "fanzonem"
+    fatfursp:
+      description: "fatfursp"
+      children:
+        fatfurspa: "fatfurspa"
+    fatfury1:
+      description: "fatfury1"
+    fatfury2:
+      description: "fatfury2"
+    fatfury3:
+      description: "fatfury3"
+    fbfrenzy:
+      description: "fbfrenzy"
+    ffight:
+      description: "ffight"
+      children:
+        ffighta: "ffighta"
+        ffightae: "ffightae"
+        ffightj: "ffightj"
+        ffightj1: "ffightj1"
+        ffightj2: "ffightj2"
+        ffightj3: "ffightj3"
+        ffightj4: "ffightj4"
+        ffightu: "ffightu"
+        ffightu1: "ffightu1"
+        ffightua: "ffightua"
+        ffightub: "ffightub"
+        ffightuc: "ffightuc"
+    ffreveng:
+      description: "ffreveng"
+      children:
+        ffrevng10: "ffrevng10"
+    fgoal:
+      description: "fgoal"
+      children:
+        fgoala: "fgoala"
+    fhawk:
+      description: "fhawk"
+      children:
+        fhawkj: "fhawkj"
+    fhboxers:
+      description: "fhboxers"
+    fieldday:
+      description: "fieldday"
+      children:
+        undoukai: "undoukai"
+    fightfev:
+      description: "fightfev"
+      children:
+        fightfeva: "fightfeva"
+    finalb:
+      description: "finalb"
+      children:
+        finalbj: "finalbj"
+        finalbu: "finalbu"
+    finalizr:
+      description: "finalizr"
+      children:
+        finalizra: "finalizra"
+        finalizrb: "finalizrb"
+    findlove:
+      description: "findlove"
+    firebatl:
+      description: "firebatl"
+    fitegolf:
+      description: "fitegolf"
+      children:
+        fitegolfu: "fitegolfu"
+        fitegolfua: "fitegolfua"
+    flicky:
+      description: "flicky"
+    flipshot:
+      description: "flipshot"
+    flstory:
+      description: "flstory"
+      children:
+        flstoryo: "flstoryo"
+    footchmp:
+      description: "footchmp"
+      children:
+        footchmpbl: "footchmpbl"
+        hthero: "hthero"
+    forgottn:
+      description: "forgottn"
+      children:
+        forgottna: "forgottna"
+        forgottnj: "forgottnj"
+        forgottnu: "forgottnu"
+        forgottnua: "forgottnua"
+        forgottnuaa: "forgottnuaa"
+        forgottnuc: "forgottnuc"
+        forgottnue: "forgottnue"
+        lostwrld: "lostwrld"
+        lostwrldo: "lostwrldo"
+    fpoint:
+      description: "fpoint"
+      children:
+        fpoint1: "fpoint1"
+    friskyt:
+      description: "friskyt"
+      children:
+        friskyta: "friskyta"
+        friskytb: "friskytb"
+    frogger:
+      description: "frogger"
+      children:
+        frogf: "frogf"
+        frogg: "frogg"
+        froggeg: "froggeg"
+        froggeram: "froggeram"
+        froggereb: "froggereb"
+        froggermc: "froggermc"
+        froggers: "froggers"
+        froggers1: "froggers1"
+        froggers2: "froggers2"
+        froggers3: "froggers3"
+        froggert: "froggert"
+        froggerv: "froggerv"
+        froggervd: "froggervd"
+    frogs:
+      description: "frogs"
+    froman2b:
+      description: "froman2b"
+    fsoccer:
+      description: "fsoccer"
+      children:
+        fsoccerb: "fsoccerb"
+        fsoccerba: "fsoccerba"
+        fsoccerj: "fsoccerj"
+    futspy:
+      description: "futspy"
+    fvipers:
+      description: "fvipers"
+      children:
+        fvipersb: "fvipersb"
+    fvipers2:
+      description: "fvipers2"
+      children:
+        fvipers2o: "fvipers2o"
+    ga2:
+      description: "ga2"
+      children:
+        ga2j: "ga2j"
+        ga2u: "ga2u"
+    gal10ren:
+      description: "gal10ren"
+    galastrm:
+      description: "galastrm"
+    galaxyfg:
+      description: "galaxyfg"
+    galivan:
+      description: "galivan"
+      children:
+        galivan2: "galivan2"
+        galivan3: "galivan3"
+    galkaika:
+      description: "galkaika"
+    galkoku:
+      description: "galkoku"
+      children:
+        galkokua: "galkokua"
+        hyouban: "hyouban"
+    galmedes:
+      description: "galmedes"
+    ganbare:
+      description: "ganbare"
+    gangwars:
+      description: "gangwars"
+      children:
+        gangwarsb: "gangwarsb"
+        gangwarsj: "gangwarsj"
+        gangwarsu: "gangwarsu"
+    ganryu:
+      description: "ganryu"
+    gardia:
+      description: "gardia"
+      children:
+        gardiaj: "gardiaj"
+    garou:
+      description: "garou"
+      children:
+        garoubl: "garoubl"
+        garoup: "garoup"
+    gaxeduel:
+      description: "gaxeduel"
+    gberet:
+      description: "gberet"
+      children:
+        gberetb: "gberetb"
+        rushatck: "rushatck"
+    gekiridn:
+      description: "gekiridn"
+      children:
+        gekiridnj: "gekiridnj"
+    gforce2:
+      description: "gforce2"
+      children:
+        gforce2j: "gforce2j"
+        gforce2ja: "gforce2ja"
+        gforce2sd: "gforce2sd"
+    gground:
+      description: "gground"
+      children:
+        ggroundj: "ggroundj"
+    ghostlop:
+      description: "ghostlop"
+    ghouls:
+      description: "ghouls"
+      children:
+        daimakai: "daimakai"
+        daimakair: "daimakair"
+        ghoulsu: "ghoulsu"
+    gigandes:
+      description: "gigandes"
+      children:
+        gigandesa: "gigandesa"
+        gigandesj: "gigandesj"
+    gigawing:
+      description: "gigawing"
+      children:
+        gigawinga: "gigawinga"
+        gigawingb: "gigawingb"
+        gigawingd: "gigawingd"
+        gigawingh: "gigawingh"
+        gigawingj: "gigawingj"
+        gigawingjd: "gigawingjd"
+    gionbana:
+      description: "gionbana"
+    gloc:
+      description: "gloc"
+      children:
+        glocr360: "glocr360"
+        glocr360j: "glocr360j"
+        glocu: "glocu"
+    gng:
+      description: "gng"
+      children:
+        gnga: "gnga"
+        gngbl: "gngbl"
+        gngblita: "gngblita"
+        gngc: "gngc"
+        gngprot: "gngprot"
+        gngt: "gngt"
+        makaimur: "makaimur"
+        makaimurc: "makaimurc"
+        makaimurg: "makaimurg"
+    goalx3:
+      description: "goalx3"
+    goldmedl:
+      description: "goldmedl"
+    goldnaxe:
+      description: "goldnaxe"
+      children:
+        goldnaxe1: "goldnaxe1"
+        goldnaxe2: "goldnaxe2"
+        goldnaxe3: "goldnaxe3"
+        goldnaxej: "goldnaxej"
+        goldnaxeu: "goldnaxeu"
+    goonies:
+      description: "goonies"
+    gowcaizr:
+      description: "gowcaizr"
+    gpilots:
+      description: "gpilots"
+      children:
+        gpilotsp: "gpilotsp"
+    gprider:
+      description: "gprider"
+      children:
+        gpriderj: "gpriderj"
+        gpriderjs: "gpriderjs"
+        gpriders: "gpriders"
+        gprideru: "gprideru"
+        gpriderus: "gpriderus"
+    grchamp:
+      description: "grchamp"
+      children:
+        grchampa: "grchampa"
+        grchampb: "grchampb"
+    grdforce:
+      description: "grdforce"
+    greenber:
+      description: "greenber"
+    groovef:
+      description: "groovef"
+    groundfx:
+      description: "groundfx"
+    growl:
+      description: "growl"
+      children:
+        growla: "growla"
+        growlp: "growlp"
+        growlu: "growlu"
+        runark: "runark"
+    gseeker:
+      description: "gseeker"
+      children:
+        gseekerj: "gseekerj"
+        gseekeru: "gseekeru"
+    gsword:
+      description: "gsword"
+      children:
+        gsword2: "gsword2"
+    gulunpa:
+      description: "gulunpa"
+    gunblade:
+      description: "gunblade"
+    gunbustr:
+      description: "gunbustr"
+      children:
+        gunbustrj: "gunbustrj"
+        gunbustru: "gunbustru"
+    gunforc2:
+      description: "gunforc2"
+      children:
+        geostorm: "geostorm"
+        geostorma: "geostorma"
+    gunforce:
+      description: "gunforce"
+      children:
+        gunforcej: "gunforcej"
+        gunforceu: "gunforceu"
+    gunfront:
+      description: "gunfront"
+      children:
+        gunfrontj: "gunfrontj"
+    gunlock:
+      description: "gunlock"
+      children:
+        gunlocko: "gunlocko"
+        rayforce: "rayforce"
+        rayforcej: "rayforcej"
+    gunsmoke:
+      description: "gunsmoke"
+      children:
+        gunsmokeb: "gunsmokeb"
+        gunsmokeg: "gunsmokeg"
+        gunsmokej: "gunsmokej"
+        gunsmokeu: "gunsmokeu"
+        gunsmokeua: "gunsmokeua"
+        gunsmokeub: "gunsmokeub"
+    gururin:
+      description: "gururin"
+    gwar:
+      description: "gwar"
+      children:
+        gwara: "gwara"
+        gwarab: "gwarab"
+        gwarb: "gwarb"
+        gwarj: "gwarj"
+    gwarrior:
+      description: "gwarrior"
+    gyruss:
+      description: "gyruss"
+      children:
+        gyrussb: "gyrussb"
+        gyrussce: "gyrussce"
+        venus: "venus"
+    hal21:
+      description: "hal21"
+      children:
+        hal21j: "hal21j"
+    halleysc:
+      description: "halleysc"
+      children:
+        halleysc87: "halleysc87"
+        halleyscj: "halleyscj"
+        halleyscja: "halleyscja"
+        halleyscjp: "halleyscjp"
+    hamaway:
+      description: "hamaway"
+    hanagumi:
+      description: "hanagumi"
+    hanamomo:
+      description: "hanamomo"
+      children:
+        hanamomb: "hanamomb"
+    hanaoji:
+      description: "hanaoji"
+      children:
+        hanaojia: "hanaojia"
+    hangon:
+      description: "hangon"
+      children:
+        hangon1: "hangon1"
+        hangon2: "hangon2"
+    hangonjr:
+      description: "hangonjr"
+    harddunk:
+      description: "harddunk"
+      children:
+        harddunkj: "harddunkj"
+    harley:
+      description: "harley"
+      children:
+        harleya: "harleya"
+    hasamu:
+      description: "hasamu"
+    headon:
+      description: "headon"
+      children:
+        bumba: "bumba"
+        colision: "colision"
+        headon1: "headon1"
+        headonmz: "headonmz"
+        headonn: "headonn"
+        headons: "headons"
+        headonsa: "headonsa"
+        hocrash: "hocrash"
+        supcrash: "supcrash"
+    headon2:
+      description: "headon2"
+      children:
+        car2: "car2"
+        headon2s: "headon2s"
+        headon2sl: "headon2sl"
+    headoni:
+      description: "headoni"
+    heiankyo:
+      description: "heiankyo"
+    helifire:
+      description: "helifire"
+      children:
+        helifirea: "helifirea"
+    hharry:
+      description: "hharry"
+      children:
+        dkgensan: "dkgensan"
+        dkgensanm72: "dkgensanm72"
+        dkgensanm82: "dkgensanm82"
+        hharryu: "hharryu"
+    higemaru:
+      description: "higemaru"
+    highsplt:
+      description: "highsplt"
+      children:
+        highsplta: "highsplta"
+        highspltb: "highspltb"
+    hitice:
+      description: "hitice"
+      children:
+        hiticej: "hiticej"
+        hiticerb: "hiticerb"
+    hnageman:
+      description: "hnageman"
+    hnxmasev:
+      description: "hnxmasev"
+    hogalley:
+      description: "hogalley"
+    holo:
+      description: "holo"
+    hook:
+      description: "hook"
+      children:
+        hookj: "hookj"
+        hooku: "hooku"
+    horekid:
+      description: "horekid"
+      children:
+        boobhack: "boobhack"
+        horekidb: "horekidb"
+        horekidb2: "horekidb2"
+    horizon:
+      description: "horizon"
+    horshoes:
+      description: "horshoes"
+    hotd:
+      description: "hotd"
+      children:
+        hotdo: "hotdo"
+        hotdp: "hotdp"
+    hotrod:
+      description: "hotrod"
+      children:
+        hotroda: "hotroda"
+        hotrodj: "hotrodj"
+        hotrodja: "hotrodja"
+    housemn2:
+      description: "housemn2"
+    housemnq:
+      description: "housemnq"
+    hpyagu98:
+      description: "hpyagu98"
+    hsf2:
+      description: "hsf2"
+      children:
+        hsf2a: "hsf2a"
+        hsf2d: "hsf2d"
+        hsf2j: "hsf2j"
+        hsf2j1: "hsf2j1"
+    hustler:
+      description: "hustler"
+      children:
+        billiard: "billiard"
+        hustlerb: "hustlerb"
+        hustlerb2: "hustlerb2"
+        hustlerb4: "hustlerb4"
+        hustlerb5: "hustlerb5"
+        hustlerb6: "hustlerb6"
+        hustlerb7: "hustlerb7"
+        hustlerd: "hustlerd"
+        vpool: "vpool"
+    hvymetal:
+      description: "hvymetal"
+    hwchamp:
+      description: "hwchamp"
+      children:
+        hwchampa: "hwchampa"
+        hwchampj: "hwchampj"
+    hwrace:
+      description: "hwrace"
+    hyhoo:
+      description: "hyhoo"
+    hyhoo2:
+      description: "hyhoo2"
+    hyperspt:
+      description: "hyperspt"
+      children:
+        hpolym84: "hpolym84"
+        hypersptb: "hypersptb"
+    iceclimb:
+      description: "iceclimb"
+      children:
+        iceclimba: "iceclimba"
+    ichir:
+      description: "ichir"
+      children:
+        ichirj: "ichirj"
+        ichirk: "ichirk"
+    idhimitu:
+      description: "idhimitu"
+    iemoto:
+      description: "iemoto"
+      children:
+        iemotom: "iemotom"
+        ryuuha: "ryuuha"
+    ikari:
+      description: "ikari"
+      children:
+        ikaria: "ikaria"
+        ikaria2: "ikaria2"
+        ikarijp: "ikarijp"
+        ikarijpb: "ikarijpb"
+        ikarinc: "ikarinc"
+    ikari3:
+      description: "ikari3"
+      children:
+        ikari3j: "ikari3j"
+        ikari3k: "ikari3k"
+        ikari3u: "ikari3u"
+        ikari3w: "ikari3w"
+    imekura:
+      description: "imekura"
+    imgfight:
+      description: "imgfight"
+      children:
+        imgfightj: "imgfightj"
+    imsorry:
+      description: "imsorry"
+      children:
+        kimsorryj: "kimsorryj"
+    indy500:
+      description: "indy500"
+      children:
+        indy500d: "indy500d"
+        indy500to: "indy500to"
+    insectx:
+      description: "insectx"
+      children:
+        insectxbl: "insectxbl"
+        insectxj: "insectxj"
+    intcup94:
+      description: "intcup94"
+      children:
+        intcup94a: "intcup94a"
+    inthunt:
+      description: "inthunt"
+      children:
+        inthuntu: "inthuntu"
+        kaiteids: "kaiteids"
+    introdon:
+      description: "introdon"
+    invaders:
+      description: "invaders"
+      children:
+        alieninv: "alieninv"
+        alieninvp2: "alieninvp2"
+        cosmicin: "cosmicin"
+        cosmicm2: "cosmicm2"
+        cosmicmo: "cosmicmo"
+        darthvdr: "darthvdr"
+        galmonst: "galmonst"
+        invader4: "invader4"
+        invaderl: "invaderl"
+        invadernc: "invadernc"
+        invadersem: "invadersem"
+        invadrmr: "invadrmr"
+        invasion: "invasion"
+        invasiona: "invasiona"
+        invasiona2: "invasiona2"
+        invasionb: "invasionb"
+        invasionrz: "invasionrz"
+        invasionrza: "invasionrza"
+        jspecter: "jspecter"
+        jspecter2: "jspecter2"
+        searthie: "searthie"
+        searthin: "searthin"
+        searthina: "searthina"
+        sicv: "sicv"
+        sicv1: "sicv1"
+        sinvemag: "sinvemag"
+        sinvemag2: "sinvemag2"
+        sinvzen: "sinvzen"
+        sisv1: "sisv1"
+        sisv2: "sisv2"
+        sisv3: "sisv3"
+        sisv4: "sisv4"
+        sitv: "sitv"
+        sitv1: "sitv1"
+        spaceat2: "spaceat2"
+        spaceatt: "spaceatt"
+        spaceatt2k: "spaceatt2k"
+        spaceattbp: "spaceattbp"
+        spacecom: "spacecom"
+        spacerng: "spacerng"
+        spacewr3: "spacewr3"
+        spcebttl: "spcebttl"
+        spceking: "spceking"
+        spcewarla: "spcewarla"
+        spcewars: "spcewars"
+        superinv: "superinv"
+        supinvsion: "supinvsion"
+        swipeout: "swipeout"
+        tst_invd: "tst_invd"
+        ultrainv: "ultrainv"
+    invadpt2:
+      description: "invadpt2"
+      children:
+        invaddlx: "invaddlx"
+        invadpt2a: "invadpt2a"
+        invadpt2br: "invadpt2br"
+        moonbase: "moonbase"
+        moonbasea: "moonbasea"
+    invcarht:
+      description: "invcarht"
+    invds:
+      description: "invds"
+    invho2:
+      description: "invho2"
+      children:
+        invho2a: "invho2a"
+    invinco:
+      description: "invinco"
+    invqix:
+      description: "invqix"
+    ipminvad:
+      description: "ipminvad"
+      children:
+        ipminvad1: "ipminvad1"
+    ironclad:
+      description: "ironclad"
+      children:
+        ironclado: "ironclado"
+    ironhors:
+      description: "ironhors"
+      children:
+        dairesya: "dairesya"
+        farwest: "farwest"
+        ironhorsh: "ironhorsh"
+    irrmaze:
+      description: "irrmaze"
+    itaten:
+      description: "itaten"
+    ixion:
+      description: "ixion"
+    jackal:
+      description: "jackal"
+      children:
+        jackalbl: "jackalbl"
+        jackalj: "jackalj"
+        topgunbl: "topgunbl"
+        topgunr: "topgunr"
+    jailbrek:
+      description: "jailbrek"
+      children:
+        jailbrekb: "jailbrekb"
+        manhatan: "manhatan"
+    jajamaru:
+      description: "jajamaru"
+    janbari:
+      description: "janbari"
+      children:
+        mjanbari: "mjanbari"
+    jangou:
+      description: "jangou"
+    janshin:
+      description: "janshin"
+    jcross:
+      description: "jcross"
+      children:
+        jcrossa: "jcrossa"
+    jituroku:
+      description: "jituroku"
+    jngolady:
+      description: "jngolady"
+    jockeygp:
+      description: "jockeygp"
+      children:
+        jockeygpa: "jockeygpa"
+    jojo:
+      description: "jojo"
+      children:
+        jojoa: "jojoa"
+        jojoar1: "jojoar1"
+        jojoar2: "jojoar2"
+        jojoj: "jojoj"
+        jojojr1: "jojojr1"
+        jojojr2: "jojojr2"
+        jojon: "jojon"
+        jojonr1: "jojonr1"
+        jojonr2: "jojonr2"
+        jojor1: "jojor1"
+        jojor2: "jojor2"
+        jojou: "jojou"
+        jojour1: "jojour1"
+        jojour2: "jojour2"
+    jojoba:
+      description: "jojoba"
+      children:
+        jojobaj: "jojobaj"
+        jojobajr1: "jojobajr1"
+        jojoban: "jojoban"
+        jojobane: "jojobane"
+        jojobaner1: "jojobaner1"
+        jojobanr1: "jojobanr1"
+        jojobar1: "jojobar1"
+    jongbou:
+      description: "jongbou"
+    josvolly:
+      description: "josvolly"
+    joyfulr:
+      description: "joyfulr"
+      children:
+        mnchmobl: "mnchmobl"
+    joyjoy:
+      description: "joyjoy"
+    jpark:
+      description: "jpark"
+      children:
+        jparkj: "jparkj"
+        jparkja: "jparkja"
+        jparkjc: "jparkjc"
+    junglek:
+      description: "junglek"
+      children:
+        jungleby: "jungleby"
+        jungleh: "jungleh"
+        junglehbr: "junglehbr"
+        junglekas: "junglekas"
+        junglekj2: "junglekj2"
+        junglekj2a: "junglekj2a"
+        piratpet: "piratpet"
+    jungler:
+      description: "jungler"
+      children:
+        junglero: "junglero"
+        junglers: "junglers"
+        savanna: "savanna"
+    junofrst:
+      description: "junofrst"
+      children:
+        junofrstg: "junofrstg"
+    jyangoku:
+      description: "jyangoku"
+    kabukikl:
+      description: "kabukikl"
+    kabukiz:
+      description: "kabukiz"
+      children:
+        kabukizj: "kabukizj"
+    kageki:
+      description: "kageki"
+      children:
+        kagekih: "kagekih"
+        kagekij: "kagekij"
+        kagekiu: "kagekiu"
+    kaguya:
+      description: "kaguya"
+      children:
+        kaguyaa: "kaguyaa"
+    kaguya2:
+      description: "kaguya2"
+      children:
+        kaguya2f: "kaguya2f"
+    kaiserkn:
+      description: "kaiserkn"
+      children:
+        gblchmp: "gblchmp"
+        kaiserknj: "kaiserknj"
+    kamikaze:
+      description: "kamikaze"
+      children:
+        astinvad: "astinvad"
+        astinvadb: "astinvadb"
+        betafrce: "betafrce"
+        kosmokil: "kosmokil"
+    kanatuen:
+      description: "kanatuen"
+      children:
+        kyuhito: "kyuhito"
+    karnovr:
+      description: "karnovr"
+    kenseim:
+      description: "kenseim"
+    kickboy:
+      description: "kickboy"
+    kicker:
+      description: "kicker"
+      children:
+        shaolinb: "shaolinb"
+        shaolins: "shaolins"
+    kicknrun:
+      description: "kicknrun"
+      children:
+        kicknrunu: "kicknrunu"
+        mexico86: "mexico86"
+        mexico86a: "mexico86a"
+    kidniki:
+      description: "kidniki"
+      children:
+        kidnikiu: "kidnikiu"
+        lithero: "lithero"
+        yanchamr: "yanchamr"
+    kikcubic:
+      description: "kikcubic"
+      children:
+        kikcubicb: "kikcubicb"
+    kikikai:
+      description: "kikikai"
+      children:
+        knightb: "knightb"
+        knightba: "knightba"
+    kirameki:
+      description: "kirameki"
+    kiwames:
+      description: "kiwames"
+    kizuna:
+      description: "kizuna"
+    kizuna4p:
+      description: "kizuna4p"
+    knights:
+      description: "knights"
+      children:
+        knightsja: "knightsja"
+        knightsjb: "knightsjb"
+        knightsu: "knightsu"
+    kod:
+      description: "kod"
+      children:
+        kodj: "kodj"
+        kodja: "kodja"
+        kodr1: "kodr1"
+        kodr2: "kodr2"
+        kodu: "kodu"
+    kof2000:
+      description: "kof2000"
+      children:
+        kof2000n: "kof2000n"
+    kof2001:
+      description: "kof2001"
+      children:
+        ct2k3sa: "ct2k3sa"
+        ct2k3sp: "ct2k3sp"
+        cthd2003: "cthd2003"
+    kof2002:
+      description: "kof2002"
+      children:
+        kf10thep: "kf10thep"
+        kf2k2mp: "kf2k2mp"
+        kf2k2mp2: "kf2k2mp2"
+        kf2k2pla: "kf2k2pla"
+        kf2k2pls: "kf2k2pls"
+        kf2k5uni: "kf2k5uni"
+        kof10th: "kof10th"
+        kof2002b: "kof2002b"
+        kof2k4se: "kof2k4se"
+    kof2003:
+      description: "kof2003"
+      children:
+        kf2k3bl: "kf2k3bl"
+        kf2k3bla: "kf2k3bla"
+        kf2k3pl: "kf2k3pl"
+        kf2k3upl: "kf2k3upl"
+    kof94:
+      description: "kof94"
+    kof95:
+      description: "kof95"
+      children:
+        kof95a: "kof95a"
+    kof96:
+      description: "kof96"
+    kof97:
+      description: "kof97"
+      children:
+        kof97k: "kof97k"
+        kof97oro: "kof97oro"
+        kof97pls: "kof97pls"
+        kog: "kog"
+    kof98:
+      description: "kof98"
+      children:
+        kof98a: "kof98a"
+        kof98k: "kof98k"
+        kof98ka: "kof98ka"
+    kof99:
+      description: "kof99"
+      children:
+        kof99e: "kof99e"
+        kof99k: "kof99k"
+        kof99ka: "kof99ka"
+        kof99p: "kof99p"
+    koinomp:
+      description: "koinomp"
+    kokoroj:
+      description: "kokoroj"
+      children:
+        kokoroja: "kokoroja"
+    kokoroj2:
+      description: "kokoroj2"
+    konamigt:
+      description: "konamigt"
+      children:
+        rf2: "rf2"
+    korinai:
+      description: "korinai"
+      children:
+        korinaim: "korinaim"
+    koshien:
+      description: "koshien"
+    kotm:
+      description: "kotm"
+    kotm2:
+      description: "kotm2"
+      children:
+        kotm2a: "kotm2a"
+        kotm2p: "kotm2p"
+    kozure:
+      description: "kozure"
+    kram:
+      description: "kram"
+      children:
+        kram2: "kram2"
+        kram3: "kram3"
+    ksayakyu:
+      description: "ksayakyu"
+    kungfum:
+      description: "kungfum"
+      children:
+        spartanx: "spartanx"
+    kurikint:
+      description: "kurikint"
+      children:
+        kurikinta: "kurikinta"
+        kurikintj: "kurikintj"
+        kurikintu: "kurikintu"
+        kurikintw: "kurikintw"
+    lamachin:
+      description: "lamachin"
+    landmakr:
+      description: "landmakr"
+      children:
+        landmakrj: "landmakrj"
+        landmakrp: "landmakrp"
+    lasso:
+      description: "lasso"
+    lastblad:
+      description: "lastblad"
+      children:
+        lastsold: "lastsold"
+    lastbld2:
+      description: "lastbld2"
+    lastbrnx:
+      description: "lastbrnx"
+      children:
+        lastbrnxj: "lastbrnxj"
+        lastbrnxu: "lastbrnxu"
+    lasthope:
+      description: "lasthope"
+    lastsurv:
+      description: "lastsurv"
+    lbowling:
+      description: "lbowling"
+    ldmj1mbh:
+      description: "ldmj1mbh"
+    ldquiz4:
+      description: "ldquiz4"
+    ldrun:
+      description: "ldrun"
+      children:
+        ldruna: "ldruna"
+    ldrun2:
+      description: "ldrun2"
+    ldrun3:
+      description: "ldrun3"
+      children:
+        ldrun3j: "ldrun3j"
+    ldrun4:
+      description: "ldrun4"
+    legendos:
+      description: "legendos"
+    legion:
+      description: "legion"
+      children:
+        legionj: "legionj"
+        legionj2: "legionj2"
+        legionjb: "legionjb"
+        legionjb2: "legionjb2"
+    lemans24:
+      description: "lemans24"
+    lethalth:
+      description: "lethalth"
+      children:
+        thndblst: "thndblst"
+    lghost:
+      description: "lghost"
+      children:
+        lghostd: "lghostd"
+        lghostud: "lghostud"
+    lghostj:
+      description: "lghostj"
+    lghostu:
+      description: "lghostu"
+    lgp:
+      description: "lgp"
+      children:
+        lgpalt: "lgpalt"
+    lightbr:
+      description: "lightbr"
+      children:
+        dungeonmo: "dungeonmo"
+        dungeonmu: "dungeonmu"
+        lightbrj: "lightbrj"
+    liquidk:
+      description: "liquidk"
+      children:
+        liquidku: "liquidku"
+        mizubaku: "mizubaku"
+    livegal:
+      description: "livegal"
+    lkage:
+      description: "lkage"
+      children:
+        lkageb: "lkageb"
+        lkagebl1: "lkagebl1"
+        lkagebl2: "lkagebl2"
+        lkagebl3: "lkagebl3"
+        lkagebl4: "lkagebl4"
+    lockonph:
+      description: "lockonph"
+    locomotn:
+      description: "locomotn"
+      children:
+        cottong: "cottong"
+        gutangtn: "gutangtn"
+        gutangtns: "gutangtns"
+        guttangt: "guttangt"
+        guttangts3: "guttangts3"
+        locoboot: "locoboot"
+    loffire:
+      description: "loffire"
+      children:
+        loffirej: "loffirej"
+        loffireu: "loffireu"
+    loht:
+      description: "loht"
+      children:
+        lohtj: "lohtj"
+    lostwsga:
+      description: "lostwsga"
+      children:
+        lostwsgp: "lostwsgp"
+    lotlot:
+      description: "lotlot"
+    lrescue:
+      description: "lrescue"
+      children:
+        desterth: "desterth"
+        escmars: "escmars"
+        grescue: "grescue"
+        lrescueabl: "lrescueabl"
+        lrescuem: "lrescuem"
+        lrescuem2: "lrescuem2"
+        mlander: "mlander"
+        resclunar: "resclunar"
+    lresort:
+      description: "lresort"
+      children:
+        lresortp: "lresortp"
+    lsasquad:
+      description: "lsasquad"
+      children:
+        storming: "storming"
+        storminga: "storminga"
+    ltswords:
+      description: "ltswords"
+      children:
+        kengo: "kengo"
+        kengoj: "kengoj"
+    luckygrl:
+      description: "luckygrl"
+    lupin3:
+      description: "lupin3"
+      children:
+        lupin3a: "lupin3a"
+    lwings:
+      description: "lwings"
+      children:
+        lwings2: "lwings2"
+        lwingsb: "lwingsb"
+        lwingsj: "lwingsj"
+        lwingsja: "lwingsja"
+    macha:
+      description: "macha"
+    madcrash:
+      description: "madcrash"
+      children:
+        madcrush: "madcrush"
+    magdrop2:
+      description: "magdrop2"
+    magdrop3:
+      description: "magdrop3"
+    maglord:
+      description: "maglord"
+    magmax:
+      description: "magmax"
+      children:
+        magmaxa: "magmaxa"
+    magtruck:
+      description: "magtruck"
+    magzun:
+      description: "magzun"
+    mahmajn:
+      description: "mahmajn"
+    mahmajn2:
+      description: "mahmajn2"
+    mahretsu:
+      description: "mahretsu"
+    maiko:
+      description: "maiko"
+    mainsnk:
+      description: "mainsnk"
+    majtitl2:
+      description: "majtitl2"
+      children:
+        majtitl2a: "majtitl2a"
+        majtitl2b: "majtitl2b"
+        majtitl2j: "majtitl2j"
+        skingame: "skingame"
+        skingame2: "skingame2"
+    majtitle:
+      description: "majtitle"
+      children:
+        majtitlej: "majtitlej"
+    manxtt:
+      description: "manxtt"
+      children:
+        manxttc: "manxttc"
+        manxttdx: "manxttdx"
+    marinedt:
+      description: "marinedt"
+    mariner:
+      description: "mariner"
+      children:
+        800fath: "800fath"
+        800fatha: "800fatha"
+    mario:
+      description: "mario"
+      children:
+        mariobl: "mariobl"
+        mariobla: "mariobla"
+        mariof: "mariof"
+        marioj: "marioj"
+        pestplce: "pestplce"
+    maruchan:
+      description: "maruchan"
+    marukodq:
+      description: "marukodq"
+    marvins:
+      description: "marvins"
+    masterw:
+      description: "masterw"
+      children:
+        masterwj: "masterwj"
+        masterwu: "masterwu"
+        yukiwo: "yukiwo"
+    matchit:
+      description: "matchit"
+      children:
+        shisen: "shisen"
+        sichuan2: "sichuan2"
+        sichuan2a: "sichuan2a"
+    matchit2:
+      description: "matchit2"
+      children:
+        shisen2: "shisen2"
+    matrim:
+      description: "matrim"
+      children:
+        matrimbl: "matrimbl"
+    mausuke:
+      description: "mausuke"
+    mbombrd:
+      description: "mbombrd"
+      children:
+        mbombrdj: "mbombrdj"
+    mcontest:
+      description: "mcontest"
+    mechatt:
+      description: "mechatt"
+      children:
+        mechattj: "mechattj"
+        mechattu: "mechattu"
+        mechattu1: "mechattu1"
+    megablst:
+      description: "megablst"
+      children:
+        megablstj: "megablstj"
+        megablstu: "megablstu"
+    megaman:
+      description: "megaman"
+      children:
+        megamana: "megamana"
+        rmancp2j: "rmancp2j"
+        rmancp2u: "rmancp2u"
+        rmancp2ur1: "rmancp2ur1"
+        rmancp2ur2: "rmancp2ur2"
+        rockmanj: "rockmanj"
+    megaman2:
+      description: "megaman2"
+      children:
+        megaman2a: "megaman2a"
+        megaman2d: "megaman2d"
+        megaman2h: "megaman2h"
+        rockman2j: "rockman2j"
+    megazone:
+      description: "megazone"
+      children:
+        megazonea: "megazonea"
+        megazoneb: "megazoneb"
+        megazoneh: "megazoneh"
+        megazonei: "megazonei"
+        megazonej: "megazonej"
+    megrescu:
+      description: "megrescu"
+    meijinsn:
+      description: "meijinsn"
+      children:
+        meijinsna: "meijinsna"
+    mercs:
+      description: "mercs"
+      children:
+        mercsj: "mercsj"
+        mercsu: "mercsu"
+        mercsur1: "mercsur1"
+    metalb:
+      description: "metalb"
+      children:
+        metalbj: "metalbj"
+    mgion:
+      description: "mgion"
+    mgmen89:
+      description: "mgmen89"
+    miexchng:
+      description: "miexchng"
+    mightguy:
+      description: "mightguy"
+    mikie:
+      description: "mikie"
+      children:
+        mikiehs: "mikiehs"
+        mikiej: "mikiej"
+        mikiek: "mikiek"
+    minasan:
+      description: "minasan"
+    minivadr:
+      description: "minivadr"
+    missilex:
+      description: "missilex"
+    mjcamera:
+      description: "mjcamera"
+      children:
+        mjcameram: "mjcameram"
+        mjcamerao: "mjcamerao"
+    mjegolf:
+      description: "mjegolf"
+    mjfocus:
+      description: "mjfocus"
+      children:
+        mjfocusm: "mjfocusm"
+        peepshow: "peepshow"
+    mjgaiden:
+      description: "mjgaiden"
+    mjgottsu:
+      description: "mjgottsu"
+      children:
+        bakuhatu: "bakuhatu"
+    mjgottub:
+      description: "mjgottub"
+    mjkoiura:
+      description: "mjkoiura"
+      children:
+        mkoiuraa: "mkoiuraa"
+    mjlaman:
+      description: "mjlaman"
+    mjleague:
+      description: "mjleague"
+    mjlstory:
+      description: "mjlstory"
+      children:
+        ladymakr: "ladymakr"
+    mjnanpas:
+      description: "mjnanpas"
+      children:
+        mjnanpaa: "mjnanpaa"
+        mjnanpau: "mjnanpau"
+    mjnquest:
+      description: "mjnquest"
+      children:
+        mjnquestb: "mjnquestb"
+    mjsikaku:
+      description: "mjsikaku"
+      children:
+        mjsikakb: "mjsikakb"
+        mjsikakc: "mjsikakc"
+        mjsikakd: "mjsikakd"
+        mmsikaku: "mmsikaku"
+    mjuraden:
+      description: "mjuraden"
+    mkeibaou:
+      description: "mkeibaou"
+    mladyhtr:
+      description: "mladyhtr"
+    mlanding:
+      description: "mlanding"
+      children:
+        mlandingj: "mlandingj"
+    mmagic:
+      description: "mmagic"
+    mmaiko:
+      description: "mmaiko"
+    mmatrix:
+      description: "mmatrix"
+      children:
+        mmatrixa: "mmatrixa"
+        mmatrixd: "mmatrixd"
+        mmatrixj: "mmatrixj"
+    mmehyou:
+      description: "mmehyou"
+    mofflott:
+      description: "mofflott"
+    monsterb:
+      description: "monsterb"
+      children:
+        monsterb2: "monsterb2"
+    moshougi:
+      description: "moshougi"
+    motoraid:
+      description: "motoraid"
+      children:
+        motoraiddx: "motoraiddx"
+    mpang:
+      description: "mpang"
+      children:
+        mpanga: "mpanga"
+        mpangj: "mpangj"
+        mpangr1: "mpangr1"
+        mpangu: "mpangu"
+    mpatrol:
+      description: "mpatrol"
+      children:
+        mpatrolw: "mpatrolw"
+        mranger: "mranger"
+    mpumpkin:
+      description: "mpumpkin"
+    mrgoemon:
+      description: "mrgoemon"
+    mrviking:
+      description: "mrviking"
+    mscoutm:
+      description: "mscoutm"
+    msh:
+      description: "msh"
+      children:
+        msha: "msha"
+        mshb: "mshb"
+        mshbr1: "mshbr1"
+        mshh: "mshh"
+        mshj: "mshj"
+        mshjr1: "mshjr1"
+        mshu: "mshu"
+        mshud: "mshud"
+    mshvsf:
+      description: "mshvsf"
+      children:
+        mshvsfa: "mshvsfa"
+        mshvsfa1: "mshvsfa1"
+        mshvsfb: "mshvsfb"
+        mshvsfb1: "mshvsfb1"
+        mshvsfh: "mshvsfh"
+        mshvsfj: "mshvsfj"
+        mshvsfj1: "mshvsfj1"
+        mshvsfj2: "mshvsfj2"
+        mshvsfu: "mshvsfu"
+        mshvsfu1: "mshvsfu1"
+        mshvsfu1d: "mshvsfu1d"
+    msisaac:
+      description: "msisaac"
+    msjiken:
+      description: "msjiken"
+    mslug:
+      description: "mslug"
+    mslug2:
+      description: "mslug2"
+      children:
+        mslug2t: "mslug2t"
+    mslug3:
+      description: "mslug3"
+      children:
+        mslug3a: "mslug3a"
+        mslug3b6: "mslug3b6"
+    mslug4:
+      description: "mslug4"
+      children:
+        ms4plus: "ms4plus"
+    mslug5:
+      description: "mslug5"
+      children:
+        ms5plus: "ms5plus"
+        mslug5b: "mslug5b"
+    mslugx:
+      description: "mslugx"
+    msword:
+      description: "msword"
+      children:
+        mswordj: "mswordj"
+        mswordr1: "mswordr1"
+        mswordu: "mswordu"
+    mtwins:
+      description: "mtwins"
+      children:
+        chikij: "chikij"
+    mutnat:
+      description: "mutnat"
+    mvp:
+      description: "mvp"
+      children:
+        mvpj: "mvpj"
+    mvsc:
+      description: "mvsc"
+      children:
+        mvsca: "mvsca"
+        mvscar1: "mvscar1"
+        mvscb: "mvscb"
+        mvsch: "mvsch"
+        mvscj: "mvscj"
+        mvscjr1: "mvscjr1"
+        mvscjsing: "mvscjsing"
+        mvscr1: "mvscr1"
+        mvscu: "mvscu"
+        mvscud: "mvscud"
+        mvscur1: "mvscur1"
+    mwalk:
+      description: "mwalk"
+      children:
+        walkj: "walkj"
+        walku: "walku"
+    myfairld:
+      description: "myfairld"
+    myhero:
+      description: "myhero"
+      children:
+        sscandal: "sscandal"
+    mysticri:
+      description: "mysticri"
+      children:
+        gunhohki: "gunhohki"
+    nam1975:
+      description: "nam1975"
+    nameclub:
+      description: "nameclub"
+    nastar:
+      description: "nastar"
+      children:
+        nastarw: "nastarw"
+        rastsag2: "rastsag2"
+    nbbatman:
+      description: "nbbatman"
+      children:
+        leaguemn: "leaguemn"
+        leaguemna: "leaguemna"
+        nbbatmanu: "nbbatmanu"
+    nclubdis:
+      description: "nclubdis"
+    nclubv2:
+      description: "nclubv2"
+    nclubv3:
+      description: "nclubv3"
+    nclubv4:
+      description: "nclubv4"
+    ncombat:
+      description: "ncombat"
+    ncommand:
+      description: "ncommand"
+    nemesis:
+      description: "nemesis"
+      children:
+        gradius: "gradius"
+        gradiusuk: "gradiusuk"
+    nemo:
+      description: "nemo"
+      children:
+        nemoj: "nemoj"
+        nemor1: "nemor1"
+    neobombe:
+      description: "neobombe"
+    neocup98:
+      description: "neocup98"
+    neodrift:
+      description: "neodrift"
+    neomrdo:
+      description: "neomrdo"
+    netmerc:
+      description: "netmerc"
+    newsin7:
+      description: "newsin7"
+      children:
+        newsin7a: "newsin7a"
+    ngalsumr:
+      description: "ngalsumr"
+    ngpgal:
+      description: "ngpgal"
+    ngtbunny:
+      description: "ngtbunny"
+      children:
+        royalngt: "royalngt"
+    nightgal:
+      description: "nightgal"
+    nightlov:
+      description: "nightlov"
+    nightstr:
+      description: "nightstr"
+      children:
+        nightstrj: "nightstrj"
+        nightstru: "nightstru"
+    ninjakun:
+      description: "ninjakun"
+    ninjamas:
+      description: "ninjamas"
+    ninjaw:
+      description: "ninjaw"
+      children:
+        ninjaw1: "ninjaw1"
+        ninjawj: "ninjawj"
+        ninjawu: "ninjawu"
+    ninjemak:
+      description: "ninjemak"
+      children:
+        ninjemat: "ninjemat"
+        youma: "youma"
+        youma2: "youma2"
+        youmab: "youmab"
+        youmab2: "youmab2"
+    nitd:
+      description: "nitd"
+      children:
+        nitdbl: "nitdbl"
+    nob:
+      description: "nob"
+      children:
+        nobb: "nobb"
+    nostromo:
+      description: "nostromo"
+      children:
+        startrks: "startrks"
+    nspirit:
+      description: "nspirit"
+      children:
+        nspiritj: "nspiritj"
+    nss_actr:
+      description: "nss_actr"
+    nss_adam:
+      description: "nss_adam"
+    nss_aten:
+      description: "nss_aten"
+    nss_con3:
+      description: "nss_con3"
+    nss_fzer:
+      description: "nss_fzer"
+    nss_lwep:
+      description: "nss_lwep"
+    nss_ncaa:
+      description: "nss_ncaa"
+    nss_rob3:
+      description: "nss_rob3"
+    nss_skin:
+      description: "nss_skin"
+    nss_smas:
+      description: "nss_smas"
+    nss_smw:
+      description: "nss_smw"
+    nss_ssoc:
+      description: "nss_ssoc"
+    nss_sten:
+      description: "nss_sten"
+    nsub:
+      description: "nsub"
+      children:
+        nsubc: "nsubc"
+    ntopstar:
+      description: "ntopstar"
+    nvs_machrider:
+      description: "nvs_machrider"
+      children:
+        nvs_machridera: "nvs_machridera"
+    nwarr:
+      description: "nwarr"
+      children:
+        nwarra: "nwarra"
+        nwarrb: "nwarrb"
+        nwarrh: "nwarrh"
+        nwarru: "nwarru"
+        nwarrud: "nwarrud"
+        vhuntj: "vhuntj"
+        vhuntjr1: "vhuntjr1"
+        vhuntjr1s: "vhuntjr1s"
+        vhuntjr2: "vhuntjr2"
+    oceanhun:
+      description: "oceanhun"
+      children:
+        oceanhuna: "oceanhuna"
+    ohpaipee:
+      description: "ohpaipee"
+    ojousan:
+      description: "ojousan"
+      children:
+        ojousanm: "ojousanm"
+    omotesnd:
+      description: "omotesnd"
+    opaopa:
+      description: "opaopa"
+      children:
+        opaopan: "opaopan"
+    opwolf:
+      description: "opwolf"
+      children:
+        opwolfa: "opwolfa"
+        opwolfb: "opwolfb"
+        opwolfj: "opwolfj"
+        opwolfjsc: "opwolfjsc"
+        opwolfp: "opwolfp"
+        opwolfu: "opwolfu"
+    orangec:
+      description: "orangec"
+      children:
+        orangeci: "orangeci"
+        vipclub: "vipclub"
+    orunners:
+      description: "orunners"
+      children:
+        orunnersj: "orunnersj"
+        orunnersu: "orunnersu"
+    otatidai:
+      description: "otatidai"
+    othellos:
+      description: "othellos"
+    othunder:
+      description: "othunder"
+      children:
+        othunderj: "othunderj"
+        othunderjsc: "othunderjsc"
+        othunderua: "othunderua"
+    othundero:
+      description: "othundero"
+      children:
+        othunder: "othunder"
+    otonano:
+      description: "otonano"
+    outrun:
+      description: "outrun"
+      children:
+        outrundx: "outrundx"
+        outrundxa: "outrundxa"
+        outrundxeh: "outrundxeh"
+        outrundxeha: "outrundxeha"
+        outrundxj: "outrundxj"
+        outruneh: "outruneh"
+        outruneha: "outruneha"
+        outrunra: "outrunra"
+    overrev:
+      description: "overrev"
+      children:
+        overrevb: "overrevb"
+        overrevba: "overrevba"
+    overtop:
+      description: "overtop"
+    ozmawars:
+      description: "ozmawars"
+      children:
+        ozmawars2: "ozmawars2"
+        ozmawarsmr: "ozmawarsmr"
+        solfight: "solfight"
+        spaceph: "spaceph"
+    pachiten:
+      description: "pachiten"
+    paddlema:
+      description: "paddlema"
+    pairsnb:
+      description: "pairsnb"
+      children:
+        pairsten: "pairsten"
+    palamed:
+      description: "palamed"
+      children:
+        palamedj: "palamedj"
+    pandoras:
+      description: "pandoras"
+    pang:
+      description: "pang"
+      children:
+        bbros: "bbros"
+        pangb: "pangb"
+        pangb2: "pangb2"
+        pangba: "pangba"
+        pangbb: "pangbb"
+        pangbc: "pangbc"
+        pangbold: "pangbold"
+        pangbp: "pangbp"
+        pompingw: "pompingw"
+    pang3:
+      description: "pang3"
+      children:
+        pang3j: "pang3j"
+        pang3r1: "pang3r1"
+    panicbom:
+      description: "panicbom"
+    panicr:
+      description: "panicr"
+      children:
+        panicrg: "panicrg"
+    panther:
+      description: "panther"
+    parentj:
+      description: "parentj"
+    passsht:
+      description: "passsht"
+      children:
+        cencourt: "cencourt"
+        passsht16a: "passsht16a"
+        passshta: "passshta"
+        passshtj: "passshtj"
+    pastelg:
+      description: "pastelg"
+    patimono:
+      description: "patimono"
+    patocar:
+      description: "patocar"
+    pballoon:
+      description: "pballoon"
+      children:
+        pballoonr: "pballoonr"
+    pblbeach:
+      description: "pblbeach"
+    pbobbl2n:
+      description: "pbobbl2n"
+    pbobble:
+      description: "pbobble"
+      children:
+        bublbust: "bublbust"
+    pbobble2:
+      description: "pbobble2"
+      children:
+        pbobble2j: "pbobble2j"
+        pbobble2o: "pbobble2o"
+        pbobble2u: "pbobble2u"
+        pbobble2x: "pbobble2x"
+    pbobble3:
+      description: "pbobble3"
+      children:
+        pbobble3j: "pbobble3j"
+        pbobble3u: "pbobble3u"
+    pbobble4:
+      description: "pbobble4"
+      children:
+        pbobble4j: "pbobble4j"
+        pbobble4u: "pbobble4u"
+    pbobblen:
+      description: "pbobblen"
+      children:
+        pbobblenb: "pbobblenb"
+    pc_1942:
+      description: "pc_1942"
+    pc_bball:
+      description: "pc_bball"
+    pc_bfght:
+      description: "pc_bfght"
+    pc_bload:
+      description: "pc_bload"
+    pc_bstar:
+      description: "pc_bstar"
+    pc_cntra:
+      description: "pc_cntra"
+    pc_cshwk:
+      description: "pc_cshwk"
+    pc_cvnia:
+      description: "pc_cvnia"
+    pc_dbldr:
+      description: "pc_dbldr"
+    pc_ddrgn:
+      description: "pc_ddrgn"
+    pc_drmro:
+      description: "pc_drmro"
+      children:
+        pc_virus: "pc_virus"
+    pc_duckh:
+      description: "pc_duckh"
+    pc_ebike:
+      description: "pc_ebike"
+    pc_ftqst:
+      description: "pc_ftqst"
+    pc_gntlt:
+      description: "pc_gntlt"
+    pc_golf:
+      description: "pc_golf"
+    pc_goons:
+      description: "pc_goons"
+    pc_grdus:
+      description: "pc_grdus"
+      children:
+        pc_grdue: "pc_grdue"
+    pc_hgaly:
+      description: "pc_hgaly"
+    pc_kngfu:
+      description: "pc_kngfu"
+    pc_mario:
+      description: "pc_mario"
+    pc_miket:
+      description: "pc_miket"
+    pc_mman3:
+      description: "pc_mman3"
+    pc_moglf:
+      description: "pc_moglf"
+    pc_mtoid:
+      description: "pc_mtoid"
+    pc_ngai2:
+      description: "pc_ngai2"
+    pc_ngai3:
+      description: "pc_ngai3"
+    pc_ngaid:
+      description: "pc_ngaid"
+    pc_pinbt:
+      description: "pc_pinbt"
+    pc_pwbld:
+      description: "pc_pwbld"
+    pc_pwrst:
+      description: "pc_pwrst"
+    pc_radr2:
+      description: "pc_radr2"
+    pc_radrc:
+      description: "pc_radrc"
+    pc_rcpam:
+      description: "pc_rcpam"
+    pc_rkats:
+      description: "pc_rkats"
+    pc_rnatk:
+      description: "pc_rnatk"
+    pc_rrngr:
+      description: "pc_rrngr"
+    pc_rygar:
+      description: "pc_rygar"
+    pc_sjetm:
+      description: "pc_sjetm"
+    pc_smb:
+      description: "pc_smb"
+    pc_smb2:
+      description: "pc_smb2"
+    pc_smb3:
+      description: "pc_smb3"
+    pc_suprc:
+      description: "pc_suprc"
+    pc_tbowl:
+      description: "pc_tbowl"
+    pc_tenis:
+      description: "pc_tenis"
+    pc_tkfld:
+      description: "pc_tkfld"
+    pc_tmnt:
+      description: "pc_tmnt"
+    pc_tmnt2:
+      description: "pc_tmnt2"
+    pc_trjan:
+      description: "pc_trjan"
+    pc_ttoon:
+      description: "pc_ttoon"
+    pc_vball:
+      description: "pc_vball"
+    pc_wcup:
+      description: "pc_wcup"
+    pc_wgnmn:
+      description: "pc_wgnmn"
+    pc_ynoid:
+      description: "pc_ynoid"
+    pclub2:
+      description: "pclub2"
+    pclubj:
+      description: "pclubj"
+    pclubjv2:
+      description: "pclubjv2"
+      children:
+        pclub: "pclub"
+    pclubjv4:
+      description: "pclubjv4"
+    pclubjv5:
+      description: "pclubjv5"
+    pclubpok:
+      description: "pclubpok"
+    pdrift:
+      description: "pdrift"
+      children:
+        pdrifta: "pdrifta"
+        pdrifte: "pdrifte"
+        pdriftj: "pdriftj"
+    pdriftl:
+      description: "pdriftl"
+    pengo:
+      description: "pengo"
+      children:
+        pengo2: "pengo2"
+        pengo4: "pengo4"
+        pengo5: "pengo5"
+    pgoal:
+      description: "pgoal"
+    phoenix:
+      description: "phoenix"
+      children:
+        avefenix: "avefenix"
+        avefenixl: "avefenixl"
+        avefenixrf: "avefenixrf"
+        batman2: "batman2"
+        condor: "condor"
+        condorn: "condorn"
+        condorva: "condorva"
+        falcon: "falcon"
+        fenix: "fenix"
+        fenixn: "fenixn"
+        griffon: "griffon"
+        griffono: "griffono"
+        nextfase: "nextfase"
+        phoenix2: "phoenix2"
+        phoenix3: "phoenix3"
+        phoenixa: "phoenixa"
+        phoenixass: "phoenixass"
+        phoenixb: "phoenixb"
+        phoenixbl: "phoenixbl"
+        phoenixc: "phoenixc"
+        phoenixc2: "phoenixc2"
+        phoenixc3: "phoenixc3"
+        phoenixc4: "phoenixc4"
+        phoenixdal: "phoenixdal"
+        phoenixgu: "phoenixgu"
+        phoenixha: "phoenixha"
+        phoenixi: "phoenixi"
+        phoenixj: "phoenixj"
+        phoenixs: "phoenixs"
+        phoenixt: "phoenixt"
+        phoenxp2: "phoenxp2"
+        vautour: "vautour"
+        vautourz: "vautourz"
+        vautourza: "vautourza"
+    pignewt:
+      description: "pignewt"
+      children:
+        pignewta: "pignewta"
+    pingpong:
+      description: "pingpong"
+    pitfall2:
+      description: "pitfall2"
+      children:
+        pitfall2a: "pitfall2a"
+        pitfall2u: "pitfall2u"
+    pitnrun:
+      description: "pitnrun"
+      children:
+        pitnruna: "pitnruna"
+        pitnrunb: "pitnrunb"
+    platoon:
+      description: "platoon"
+    plgirls:
+      description: "plgirls"
+      children:
+        lagirl: "lagirl"
+    plgirls2:
+      description: "plgirls2"
+      children:
+        plgirls2b: "plgirls2b"
+    plotting:
+      description: "plotting"
+      children:
+        flipull: "flipull"
+        plottinga: "plottinga"
+        plottingb: "plottingb"
+        plottingu: "plottingu"
+    pltkids:
+      description: "pltkids"
+      children:
+        pltkidsa: "pltkidsa"
+    plumppop:
+      description: "plumppop"
+    pnickj:
+      description: "pnickj"
+    pnyaa:
+      description: "pnyaa"
+      children:
+        pnyaaa: "pnyaaa"
+    pokonyan:
+      description: "pokonyan"
+    pooyan:
+      description: "pooyan"
+      children:
+        pootan: "pootan"
+        pooyans: "pooyans"
+    popbounc:
+      description: "popbounc"
+    popeye:
+      description: "popeye"
+      children:
+        popeyeb2: "popeyeb2"
+        popeyeb3: "popeyeb3"
+        popeyebl: "popeyebl"
+        popeyef: "popeyef"
+        popeyej: "popeyej"
+        popeyejo: "popeyejo"
+        popeyeu: "popeyeu"
+    popnpop:
+      description: "popnpop"
+      children:
+        popnpopj: "popnpopj"
+        popnpopu: "popnpopu"
+    potopoto:
+      description: "potopoto"
+    poundfor:
+      description: "poundfor"
+      children:
+        poundforj: "poundforj"
+        poundforu: "poundforu"
+    pow:
+      description: "pow"
+      children:
+        powa: "powa"
+        powj: "powj"
+    powsled:
+      description: "powsled"
+      children:
+        powsledm: "powsledm"
+        powsledr: "powsledr"
+    prehisle:
+      description: "prehisle"
+      children:
+        gensitou: "gensitou"
+        prehisleb: "prehisleb"
+        prehislek: "prehislek"
+        prehisleu: "prehisleu"
+    preisle2:
+      description: "preisle2"
+    prikura:
+      description: "prikura"
+    progear:
+      description: "progear"
+      children:
+        progeara: "progeara"
+        progearj: "progearj"
+        progearjbl: "progearjbl"
+        progearjd: "progearjd"
+        progearud: "progearud"
+    psailor1:
+      description: "psailor1"
+    psailor2:
+      description: "psailor2"
+    pspikes2:
+      description: "pspikes2"
+    pstadium:
+      description: "pstadium"
+    psychos:
+      description: "psychos"
+      children:
+        psychosj: "psychosj"
+    puchicar:
+      description: "puchicar"
+      children:
+        puchicarj: "puchicarj"
+        puchicaru: "puchicaru"
+    pulirula:
+      description: "pulirula"
+      children:
+        pulirulaa: "pulirulaa"
+        pulirulaj: "pulirulaj"
+    pulsar:
+      description: "pulsar"
+    pulstar:
+      description: "pulstar"
+    punchout:
+      description: "punchout"
+      children:
+        punchita: "punchita"
+        punchouta: "punchouta"
+        punchoutj: "punchoutj"
+    punisher:
+      description: "punisher"
+      children:
+        punisherh: "punisherh"
+        punisherj: "punisherj"
+        punisheru: "punisheru"
+    puyo:
+      description: "puyo"
+      children:
+        puyoja: "puyoja"
+        puyojb: "puyojb"
+    puyopuy2:
+      description: "puyopuy2"
+    puyosun:
+      description: "puyosun"
+    puzzldpr:
+      description: "puzzldpr"
+    puzzledp:
+      description: "puzzledp"
+    puzznic:
+      description: "puzznic"
+      children:
+        puzznica: "puzznica"
+        puzznicb: "puzznicb"
+        puzznici: "puzznici"
+        puzznicj: "puzznicj"
+        puzznicu: "puzznicu"
+    pwrgoal:
+      description: "pwrgoal"
+      children:
+        hthero95: "hthero95"
+        hthero95a: "hthero95a"
+        hthero95u: "hthero95u"
+    pzloop2:
+      description: "pzloop2"
+      children:
+        pzloop2j: "pzloop2j"
+        pzloop2jd: "pzloop2jd"
+        pzloop2jr1: "pzloop2jr1"
+    qad:
+      description: "qad"
+      children:
+        qadjr: "qadjr"
+    qcrayon:
+      description: "qcrayon"
+    qcrayon2:
+      description: "qcrayon2"
+    qgh:
+      description: "qgh"
+    qix:
+      description: "qix"
+      children:
+        qix2: "qix2"
+        qixa: "qixa"
+        qixb: "qixb"
+        qixo: "qixo"
+    qjinsei:
+      description: "qjinsei"
+    qmhayaku:
+      description: "qmhayaku"
+    qndream:
+      description: "qndream"
+    qrouka:
+      description: "qrouka"
+    qsww:
+      description: "qsww"
+    qtheater:
+      description: "qtheater"
+    qtono2j:
+      description: "qtono2j"
+    qtorimon:
+      description: "qtorimon"
+    quartet:
+      description: "quartet"
+      children:
+        quartet2: "quartet2"
+        quartet2a: "quartet2a"
+        quarteta: "quarteta"
+    quizdai2:
+      description: "quizdai2"
+    quizdais:
+      description: "quizdais"
+      children:
+        quizdaisk: "quizdaisk"
+    quizf1:
+      description: "quizf1"
+    quizhq:
+      description: "quizhq"
+    quizhuhu:
+      description: "quizhuhu"
+    quizkof:
+      description: "quizkof"
+      children:
+        quizkofk: "quizkofk"
+    quizmeku:
+      description: "quizmeku"
+    qzchikyu:
+      description: "qzchikyu"
+    qzquest:
+      description: "qzquest"
+    qzshowby:
+      description: "qzshowby"
+    rachero:
+      description: "rachero"
+    racingb:
+      description: "racingb"
+      children:
+        racingbj: "racingbj"
+    radarscp:
+      description: "radarscp"
+      children:
+        radarscp1: "radarscp1"
+    radm:
+      description: "radm"
+      children:
+        radmu: "radmu"
+    radr:
+      description: "radr"
+      children:
+        radrj: "radrj"
+        radru: "radru"
+    radrad:
+      description: "radrad"
+      children:
+        radradj: "radradj"
+    raflesia:
+      description: "raflesia"
+    ragnagrd:
+      description: "ragnagrd"
+    raimais:
+      description: "raimais"
+      children:
+        raimaisj: "raimaisj"
+        raimaisjo: "raimaisjo"
+    rambo3:
+      description: "rambo3"
+      children:
+        rambo3p: "rambo3p"
+        rambo3u: "rambo3u"
+    rascot:
+      description: "rascot"
+    rascot2:
+      description: "rascot2"
+    rastan:
+      description: "rastan"
+      children:
+        rastana: "rastana"
+        rastanb: "rastanb"
+        rastanu: "rastanu"
+        rastanua: "rastanua"
+        rastanub: "rastanub"
+        rastsaga: "rastsaga"
+        rastsagaa: "rastsagaa"
+        rastsagab: "rastsagab"
+    razmataz:
+      description: "razmataz"
+    rbff1:
+      description: "rbff1"
+      children:
+        rbff1a: "rbff1a"
+        rbff1k: "rbff1k"
+        rbff1ka: "rbff1ka"
+    rbff2:
+      description: "rbff2"
+      children:
+        rbff2k: "rbff2k"
+    rbffspec:
+      description: "rbffspec"
+      children:
+        rbffspeck: "rbffspeck"
+    rbisland:
+      description: "rbisland"
+      children:
+        jumping: "jumping"
+        jumpinga: "jumpinga"
+        jumpingi: "jumpingi"
+        rbislando: "rbislando"
+    rbislande:
+      description: "rbislande"
+    rchase:
+      description: "rchase"
+      children:
+        rchasej: "rchasej"
+    rchase2:
+      description: "rchase2"
+      children:
+        rchase2a: "rchase2a"
+    realpunc:
+      description: "realpunc"
+      children:
+        realpuncj: "realpuncj"
+    recalh:
+      description: "recalh"
+    recordbr:
+      description: "recordbr"
+      children:
+        gogold: "gogold"
+    redalert:
+      description: "redalert"
+      children:
+        ww3: "ww3"
+    redearth:
+      description: "redearth"
+      children:
+        redearthn: "redearthn"
+        redearthnr1: "redearthnr1"
+        redearthr1: "redearthr1"
+        warzard: "warzard"
+        warzardr1: "warzardr1"
+    regulus:
+      description: "regulus"
+    renaiclb:
+      description: "renaiclb"
+    retofinv:
+      description: "retofinv"
+      children:
+        retofinvb: "retofinvb"
+        retofinvb1: "retofinvb1"
+        retofinvb2: "retofinvb2"
+        retofinvb3: "retofinvb3"
+        retofinvbv: "retofinvbv"
+    ribbit:
+      description: "ribbit"
+      children:
+        ribbitj: "ribbitj"
+    ridhero:
+      description: "ridhero"
+    ridingf:
+      description: "ridingf"
+      children:
+        ridingfj: "ridingfj"
+        ridingfu: "ridingfu"
+    ridleofp:
+      description: "ridleofp"
+    ringdest:
+      description: "ringdest"
+      children:
+        ringdesta: "ringdesta"
+        ringdestb: "ringdestb"
+        ringdestd: "ringdestd"
+        ringdesth: "ringdesth"
+        smbomb: "smbomb"
+        smbombr1: "smbombr1"
+    ringrage:
+      description: "ringrage"
+      children:
+        ringragej: "ringragej"
+        ringrageu: "ringrageu"
+    riotcity:
+      description: "riotcity"
+    riskchal:
+      description: "riskchal"
+      children:
+        gussun: "gussun"
+    rjammer:
+      description: "rjammer"
+    roadf:
+      description: "roadf"
+      children:
+        roadf2: "roadf2"
+        roadfh: "roadfh"
+        roadfu: "roadfu"
+    roboarmy:
+      description: "roboarmy"
+      children:
+        roboarmya: "roboarmya"
+    robowres:
+      description: "robowres"
+    rockclim:
+      description: "rockclim"
+    rockrage:
+      description: "rockrage"
+      children:
+        rockragea: "rockragea"
+        rockragej: "rockragej"
+    rocnrope:
+      description: "rocnrope"
+      children:
+        rocnropek: "rocnropek"
+        ropeman: "ropeman"
+    rollingc:
+      description: "rollingc"
+    rotd:
+      description: "rotd"
+    roughrac:
+      description: "roughrac"
+    royalqn:
+      description: "royalqn"
+    roylcrdn:
+      description: "roylcrdn"
+      children:
+        roylcrdna: "roylcrdna"
+    rsgun:
+      description: "rsgun"
+    rtype:
+      description: "rtype"
+      children:
+        rtypej: "rtypej"
+        rtypejp: "rtypejp"
+        rtypeu: "rtypeu"
+    rtype2:
+      description: "rtype2"
+      children:
+        rtype2j: "rtype2j"
+        rtype2jc: "rtype2jc"
+    rtypeleo:
+      description: "rtypeleo"
+      children:
+        rtypeleoj: "rtypeleoj"
+    ryujin:
+      description: "ryujin"
+      children:
+        ryujina: "ryujina"
+    ryukyu:
+      description: "ryukyu"
+      children:
+        ryukyua: "ryukyua"
+    s1945p:
+      description: "s1945p"
+    safari:
+      description: "safari"
+      children:
+        safaria: "safaria"
+    safarir:
+      description: "safarir"
+      children:
+        safarirj: "safarirj"
+    sailorws:
+      description: "sailorws"
+      children:
+        sailorwa: "sailorwa"
+        sailorwr: "sailorwr"
+    salamand:
+      description: "salamand"
+      children:
+        lifefrce: "lifefrce"
+        lifefrcej: "lifefrcej"
+        salamandj: "salamandj"
+        salamandt: "salamandt"
+    samsh5sp:
+      description: "samsh5sp"
+    samsho:
+      description: "samsho"
+    samsho2:
+      description: "samsho2"
+      children:
+        samsho2k: "samsho2k"
+    samsho3:
+      description: "samsho3"
+      children:
+        fswords: "fswords"
+    samsho4:
+      description: "samsho4"
+      children:
+        samsho4k: "samsho4k"
+    samsho5:
+      description: "samsho5"
+      children:
+        samsho5a: "samsho5a"
+        samsho5b: "samsho5b"
+    samurai:
+      description: "samurai"
+      children:
+        samuraij: "samuraij"
+    sandor:
+      description: "sandor"
+      children:
+        thunt: "thunt"
+        thuntk: "thuntk"
+    sasissu:
+      description: "sasissu"
+      children:
+        sanjeon: "sanjeon"
+    sasuke:
+      description: "sasuke"
+    satansat:
+      description: "satansat"
+      children:
+        satansata: "satansata"
+        satansatind: "satansatind"
+    savagere:
+      description: "savagere"
+    sbasebal:
+      description: "sbasebal"
+      children:
+        sbasebalj: "sbasebalj"
+    sbasketb:
+      description: "sbasketb"
+      children:
+        sbaskete: "sbaskete"
+        sbasketg: "sbasketg"
+        sbasketh: "sbasketh"
+    sbm:
+      description: "sbm"
+      children:
+        sbmj: "sbmj"
+    sbp:
+      description: "sbp"
+    scandal:
+      description: "scandal"
+      children:
+        scandalm: "scandalm"
+    scessjoe:
+      description: "scessjoe"
+      children:
+        ashnojoe: "ashnojoe"
+    scfinals:
+      description: "scfinals"
+      children:
+        scfinalso: "scfinalso"
+    schamp:
+      description: "schamp"
+      children:
+        sfight: "sfight"
+    schaser:
+      description: "schaser"
+      children:
+        crashrd: "crashrd"
+        schasera: "schasera"
+        schaserb: "schaserb"
+        schaserc: "schaserc"
+        schasercv: "schasercv"
+        schaserm: "schaserm"
+    sci:
+      description: "sci"
+      children:
+        scia: "scia"
+        scij: "scij"
+        scin: "scin"
+        sciu: "sciu"
+    scobra:
+      description: "scobra"
+      children:
+        scobrab: "scobrab"
+        scobrae: "scobrae"
+        scobrae2: "scobrae2"
+        scobrag: "scobrag"
+        scobraggi: "scobraggi"
+        scobras: "scobras"
+        scobrase: "scobrase"
+        suprheli: "suprheli"
+    scotrsht:
+      description: "scotrsht"
+    scramble:
+      description: "scramble"
+      children:
+        astroamb: "astroamb"
+        bomber: "bomber"
+        explorer: "explorer"
+        kamikazesp: "kamikazesp"
+        ncentury: "ncentury"
+        offensiv: "offensiv"
+        scrabbleo: "scrabbleo"
+        scramb2: "scramb2"
+        scramb3: "scramb3"
+        scramblb: "scramblb"
+        scramblebb: "scramblebb"
+        scramblebf: "scramblebf"
+        scramblebun: "scramblebun"
+        scrambleo: "scrambleo"
+        scrambler: "scrambler"
+        scrambles: "scrambles"
+        scrambles2: "scrambles2"
+        scrambp: "scrambp"
+        scramce: "scramce"
+        scrammr: "scrammr"
+        scrampt: "scrampt"
+        scramrf: "scramrf"
+        seainv: "seainv"
+        spcmission: "spcmission"
+        spctrek: "spctrek"
+        strfbomb: "strfbomb"
+    scross:
+      description: "scross"
+      children:
+        scrossa: "scrossa"
+        scrossu: "scrossu"
+    scud:
+      description: "scud"
+      children:
+        scudau: "scudau"
+        scuddx: "scuddx"
+        scuddxo: "scuddxo"
+        scudplus: "scudplus"
+        scudplusa: "scudplusa"
+    scyclone:
+      description: "scyclone"
+    sdi:
+      description: "sdi"
+      children:
+        defense: "defense"
+        sdia: "sdia"
+        sdib: "sdib"
+    sdodgeb:
+      description: "sdodgeb"
+    sdungeon:
+      description: "sdungeon"
+      children:
+        sdungeona: "sdungeona"
+    seabass:
+      description: "seabass"
+    searchar:
+      description: "searchar"
+      children:
+        searcharj: "searcharj"
+        searcharu: "searcharu"
+    secolove:
+      description: "secolove"
+    sectionz:
+      description: "sectionz"
+      children:
+        sectionza: "sectionza"
+    seganinj:
+      description: "seganinj"
+      children:
+        nprincess: "nprincess"
+    segawski:
+      description: "segawski"
+    seicross:
+      description: "seicross"
+      children:
+        sectrzon: "sectrzon"
+        sectrzona: "sectrzona"
+        sectrzont: "sectrzont"
+        seicrossa: "seicrossa"
+    seiha:
+      description: "seiha"
+      children:
+        seiham: "seiham"
+    selfeena:
+      description: "selfeena"
+    sengoku:
+      description: "sengoku"
+    sengoku2:
+      description: "sengoku2"
+    sengoku3:
+      description: "sengoku3"
+    sexygal:
+      description: "sexygal"
+      children:
+        sweetgal: "sweetgal"
+    sf:
+      description: "sf"
+      children:
+        sfan: "sfan"
+        sfj: "sfj"
+        sfjan: "sfjan"
+        sfjbl: "sfjbl"
+        sfp: "sfp"
+        sfua: "sfua"
+        sfw: "sfw"
+    sf2:
+      description: "sf2"
+      children:
+        sf2ea: "sf2ea"
+        sf2eb: "sf2eb"
+        sf2ed: "sf2ed"
+        sf2em: "sf2em"
+        sf2en: "sf2en"
+        sf2j: "sf2j"
+        sf2j17: "sf2j17"
+        sf2ja: "sf2ja"
+        sf2jc: "sf2jc"
+        sf2jf: "sf2jf"
+        sf2jh: "sf2jh"
+        sf2jl: "sf2jl"
+        sf2ua: "sf2ua"
+        sf2ub: "sf2ub"
+        sf2uc: "sf2uc"
+        sf2ud: "sf2ud"
+        sf2uf: "sf2uf"
+        sf2ug: "sf2ug"
+        sf2uh: "sf2uh"
+        sf2ui: "sf2ui"
+        sf2uk: "sf2uk"
+    sf2ce:
+      description: "sf2ce"
+      children:
+        sf2ceea: "sf2ceea"
+        sf2ceja: "sf2ceja"
+        sf2cejb: "sf2cejb"
+        sf2cejc: "sf2cejc"
+        sf2cet: "sf2cet"
+        sf2ceua: "sf2ceua"
+        sf2ceub: "sf2ceub"
+        sf2ceuc: "sf2ceuc"
+    sf2hf:
+      description: "sf2hf"
+      children:
+        sf2hfj: "sf2hfj"
+        sf2hfu: "sf2hfu"
+    sfa:
+      description: "sfa"
+      children:
+        sfad: "sfad"
+        sfar1: "sfar1"
+        sfar2: "sfar2"
+        sfar3: "sfar3"
+        sfau: "sfau"
+        sfza: "sfza"
+        sfzar1: "sfzar1"
+        sfzb: "sfzb"
+        sfzbr1: "sfzbr1"
+        sfzh: "sfzh"
+        sfzhr1: "sfzhr1"
+        sfzj: "sfzj"
+        sfzjr1: "sfzjr1"
+        sfzjr2: "sfzjr2"
+    sfa2:
+      description: "sfa2"
+      children:
+        sfa2u: "sfa2u"
+        sfa2ur1: "sfa2ur1"
+        sfz2a: "sfz2a"
+        sfz2ad: "sfz2ad"
+        sfz2b: "sfz2b"
+        sfz2br1: "sfz2br1"
+        sfz2h: "sfz2h"
+        sfz2j: "sfz2j"
+        sfz2jd: "sfz2jd"
+        sfz2jr1: "sfz2jr1"
+        sfz2n: "sfz2n"
+    sfa3:
+      description: "sfa3"
+      children:
+        sfa3b: "sfa3b"
+        sfa3h: "sfa3h"
+        sfa3hr1: "sfa3hr1"
+        sfa3u: "sfa3u"
+        sfa3ud: "sfa3ud"
+        sfa3ur1: "sfa3ur1"
+        sfa3us: "sfa3us"
+        sfz3a: "sfz3a"
+        sfz3ar1: "sfz3ar1"
+        sfz3j: "sfz3j"
+        sfz3jr1: "sfz3jr1"
+        sfz3jr2: "sfz3jr2"
+        sfz3jr2d: "sfz3jr2d"
+    sfach:
+      description: "sfach"
+    sfiii:
+      description: "sfiii"
+      children:
+        sfiiia: "sfiiia"
+        sfiiih: "sfiiih"
+        sfiiij: "sfiiij"
+        sfiiin: "sfiiin"
+        sfiiina: "sfiiina"
+        sfiiiu: "sfiiiu"
+    sfiii2:
+      description: "sfiii2"
+      children:
+        sfiii2h: "sfiii2h"
+        sfiii2j: "sfiii2j"
+        sfiii2n: "sfiii2n"
+    sfiii3:
+      description: "sfiii3"
+      children:
+        sfiii3j: "sfiii3j"
+        sfiii3jr1: "sfiii3jr1"
+        sfiii3n: "sfiii3n"
+        sfiii3nr1: "sfiii3nr1"
+        sfiii3r1: "sfiii3r1"
+        sfiii3u: "sfiii3u"
+        sfiii3ur1: "sfiii3ur1"
+    sfish2:
+      description: "sfish2"
+      children:
+        sfish2j: "sfish2j"
+    sflush:
+      description: "sflush"
+    sfz2al:
+      description: "sfz2al"
+      children:
+        sfz2alb: "sfz2alb"
+        sfz2ald: "sfz2ald"
+        sfz2alh: "sfz2alh"
+        sfz2alj: "sfz2alj"
+        sfz2alr1: "sfz2alr1"
+    sfzch:
+      description: "sfzch"
+      children:
+        sfzbch: "sfzbch"
+    sgaltrop:
+      description: "sgaltrop"
+      children:
+        sgaltropa: "sgaltropa"
+    sgemf:
+      description: "sgemf"
+      children:
+        pfghtj: "pfghtj"
+        sgemfa: "sgemfa"
+        sgemfd: "sgemfd"
+        sgemfh: "sgemfh"
+    sgladiat:
+      description: "sgladiat"
+    sgmast:
+      description: "sgmast"
+      children:
+        sgmastc: "sgmastc"
+        sgmastcj: "sgmastcj"
+    sgt24h:
+      description: "sgt24h"
+    shabdama:
+      description: "shabdama"
+    shangkid:
+      description: "shangkid"
+      children:
+        hiryuken: "hiryuken"
+    shangon:
+      description: "shangon"
+      children:
+        shangon1: "shangon1"
+        shangon2: "shangon2"
+        shangon3: "shangon3"
+        shangonle: "shangonle"
+        shangonro: "shangonro"
+    shanhigw:
+      description: "shanhigw"
+    sharrier:
+      description: "sharrier"
+      children:
+        sharrier1: "sharrier1"
+    shdancer:
+      description: "shdancer"
+      children:
+        shdancer1: "shdancer1"
+        shdancerj: "shdancerj"
+    sheriff:
+      description: "sheriff"
+      children:
+        bandido: "bandido"
+        westgun2: "westgun2"
+    shienryu:
+      description: "shienryu"
+    shinobi:
+      description: "shinobi"
+      children:
+        shinobi1: "shinobi1"
+        shinobi2: "shinobi2"
+        shinobi3: "shinobi3"
+        shinobi4: "shinobi4"
+        shinobi5: "shinobi5"
+        shinobi6: "shinobi6"
+    shocktr2:
+      description: "shocktr2"
+      children:
+        lans2004: "lans2004"
+    shocktro:
+      description: "shocktro"
+      children:
+        shocktroa: "shocktroa"
+    shtrider:
+      description: "shtrider"
+      children:
+        shtridera: "shtridera"
+    sidearms:
+      description: "sidearms"
+      children:
+        sidearmsj: "sidearmsj"
+        sidearmsu: "sidearmsu"
+        sidearmsur1: "sidearmsur1"
+    silentd:
+      description: "silentd"
+      children:
+        silentdj: "silentdj"
+        silentdu: "silentdu"
+    sindbadm:
+      description: "sindbadm"
+    sjryuko:
+      description: "sjryuko"
+      children:
+        sjryuko1: "sjryuko1"
+    skichamp:
+      description: "skichamp"
+    skisuprg:
+      description: "skisuprg"
+    skyadvnt:
+      description: "skyadvnt"
+      children:
+        skyadvntj: "skyadvntj"
+        skyadvntu: "skyadvntu"
+    skychut:
+      description: "skychut"
+    skyrobo:
+      description: "skyrobo"
+      children:
+        bigfghtr: "bigfghtr"
+        skyrobobl: "skyrobobl"
+    skyskipr:
+      description: "skyskipr"
+    skysoldr:
+      description: "skysoldr"
+      children:
+        skysoldrbl: "skysoldrbl"
+    skytargt:
+      description: "skytargt"
+    slammast:
+      description: "slammast"
+      children:
+        mbomberj: "mbomberj"
+        slammastu: "slammastu"
+    slapshtr:
+      description: "slapshtr"
+    slipstrm:
+      description: "slipstrm"
+      children:
+        slipstrmh: "slipstrmh"
+    smgolf:
+      description: "smgolf"
+      children:
+        ladygolf: "ladygolf"
+        ladygolfe: "ladygolfe"
+        smgolfb: "smgolfb"
+        smgolfj: "smgolfj"
+    smgp:
+      description: "smgp"
+      children:
+        smgpj: "smgpj"
+        smgpja: "smgpja"
+    smleague:
+      description: "smleague"
+      children:
+        finlarch: "finlarch"
+    snapper:
+      description: "snapper"
+    socbrawl:
+      description: "socbrawl"
+    sokyugrt:
+      description: "sokyugrt"
+    solfigtr:
+      description: "solfigtr"
+    sonic:
+      description: "sonic"
+      children:
+        sonicp: "sonicp"
+    sonicbom:
+      description: "sonicbom"
+    soniccar:
+      description: "soniccar"
+    sonicfgt:
+      description: "sonicfgt"
+      children:
+        sonicfgtj: "sonicfgtj"
+    sonicpop:
+      description: "sonicpop"
+    sonicwi2:
+      description: "sonicwi2"
+    sonicwi3:
+      description: "sonicwi3"
+    sonson:
+      description: "sonson"
+      children:
+        sonsonj: "sonsonj"
+    spacbeam:
+      description: "spacbeam"
+    spacecr:
+      description: "spacecr"
+    spacedx:
+      description: "spacedx"
+      children:
+        spacedxj: "spacedxj"
+        spacedxo: "spacedxo"
+        spcinvdj: "spcinvdj"
+    spacefb:
+      description: "spacefb"
+      children:
+        redbird: "redbird"
+        spacebrd: "spacebrd"
+        spacedem: "spacedem"
+        spacefba: "spacefba"
+        spacefbe: "spacefbe"
+        spacefbe2: "spacefbe2"
+        spacefbg: "spacefbg"
+        starwarr: "starwarr"
+    spacefev:
+      description: "spacefev"
+      children:
+        spacefevo: "spacefevo"
+        spacefevo2: "spacefevo2"
+    spacegun:
+      description: "spacegun"
+      children:
+        spacegunj: "spacegunj"
+        spacegunu: "spacegunu"
+    spacelnc:
+      description: "spacelnc"
+    spaceod:
+      description: "spaceod"
+      children:
+        spaceod2: "spaceod2"
+    spaceskr:
+      description: "spaceskr"
+    spacetrk:
+      description: "spacetrk"
+      children:
+        spacetrkc: "spacetrkc"
+    spang:
+      description: "spang"
+      children:
+        sbbros: "sbbros"
+        spangbl: "spangbl"
+        spangbl2: "spangbl2"
+        spangj: "spangj"
+    spatter:
+      description: "spatter"
+      children:
+        ssanchan: "ssanchan"
+    spcewarl:
+      description: "spcewarl"
+      children:
+        intruder: "intruder"
+        laser: "laser"
+        spclaser: "spclaser"
+    spcinv95:
+      description: "spcinv95"
+      children:
+        akkanvdr: "akkanvdr"
+        spcinv95u: "spcinv95u"
+    spcking2:
+      description: "spcking2"
+    spcpostn:
+      description: "spcpostn"
+    spelunk2:
+      description: "spelunk2"
+    spelunkr:
+      description: "spelunkr"
+      children:
+        spelunkrj: "spelunkrj"
+    spf2t:
+      description: "spf2t"
+      children:
+        spf2ta: "spf2ta"
+        spf2td: "spf2td"
+        spf2th: "spf2th"
+        spf2tu: "spf2tu"
+        spf2xj: "spf2xj"
+        spf2xjd: "spf2xjd"
+    spidman:
+      description: "spidman"
+      children:
+        spidmanj: "spidmanj"
+        spidmanu: "spidmanu"
+    spidmanj:
+      description: "spidmanj"
+    spikeofe:
+      description: "spikeofe"
+    spikeout:
+      description: "spikeout"
+    spinmast:
+      description: "spinmast"
+    spnchout:
+      description: "spnchout"
+      children:
+        spnchouta: "spnchouta"
+        spnchoutj: "spnchoutj"
+    srally2:
+      description: "srally2"
+      children:
+        srally2dx: "srally2dx"
+        srally2p: "srally2p"
+        srally2pa: "srally2pa"
+    srallyc:
+      description: "srallyc"
+      children:
+        srallyca: "srallyca"
+        srallycb: "srallycb"
+        srallycdx: "srallycdx"
+        srallycdxa: "srallycdxa"
+    srumbler:
+      description: "srumbler"
+      children:
+        rushcrsh: "rushcrsh"
+        srumbler2: "srumbler2"
+        srumbler3: "srumbler3"
+    ssf2:
+      description: "ssf2"
+      children:
+        ssf2a: "ssf2a"
+        ssf2ar1: "ssf2ar1"
+        ssf2h: "ssf2h"
+        ssf2j: "ssf2j"
+        ssf2jr1: "ssf2jr1"
+        ssf2jr2: "ssf2jr2"
+        ssf2r1: "ssf2r1"
+        ssf2tb: "ssf2tb"
+        ssf2tba: "ssf2tba"
+        ssf2tbd: "ssf2tbd"
+        ssf2tbh: "ssf2tbh"
+        ssf2tbj: "ssf2tbj"
+        ssf2tbj1: "ssf2tbj1"
+        ssf2tbr1: "ssf2tbr1"
+        ssf2tbu: "ssf2tbu"
+        ssf2u: "ssf2u"
+        ssf2ud: "ssf2ud"
+    ssf2t:
+      description: "ssf2t"
+      children:
+        ssf2ta: "ssf2ta"
+        ssf2tad: "ssf2tad"
+        ssf2th: "ssf2th"
+        ssf2tu: "ssf2tu"
+        ssf2tur1: "ssf2tur1"
+        ssf2xj: "ssf2xj"
+        ssf2xjr1: "ssf2xjr1"
+        ssf2xjr1d: "ssf2xjr1d"
+        ssf2xjr1r: "ssf2xjr1r"
+    ssi:
+      description: "ssi"
+      children:
+        majest12j: "majest12j"
+        majest12u: "majest12u"
+        ssia: "ssia"
+    ssideki:
+      description: "ssideki"
+    ssideki2:
+      description: "ssideki2"
+    ssideki3:
+      description: "ssideki3"
+    ssideki4:
+      description: "ssideki4"
+    ssoldier:
+      description: "ssoldier"
+      children:
+        psoldier: "psoldier"
+    ssonicbr:
+      description: "ssonicbr"
+    sspacaho:
+      description: "sspacaho"
+    sspaceat:
+      description: "sspaceat"
+      children:
+        sspaceat2: "sspaceat2"
+        sspaceat3: "sspaceat3"
+        sspaceatc: "sspaceatc"
+    sspirits:
+      description: "sspirits"
+      children:
+        sspiritj: "sspiritj"
+        sspirtfc: "sspirtfc"
+    ssrj:
+      description: "ssrj"
+    sss:
+      description: "sss"
+    stakwin:
+      description: "stakwin"
+      children:
+        stakwindev: "stakwindev"
+    stakwin2:
+      description: "stakwin2"
+    starjack:
+      description: "starjack"
+      children:
+        starjacks: "starjacks"
+    starlstr:
+      description: "starlstr"
+    stcc:
+      description: "stcc"
+      children:
+        stcca: "stcca"
+        stccb: "stccb"
+        stcco: "stcco"
+    steelwkr:
+      description: "steelwkr"
+    stkclmns:
+      description: "stkclmns"
+      children:
+        stkclmnsj: "stkclmnsj"
+    stratgyx:
+      description: "stratgyx"
+      children:
+        stratgys: "stratgys"
+        strongx: "strongx"
+    streetsm:
+      description: "streetsm"
+      children:
+        streetsm1: "streetsm1"
+        streetsmj: "streetsmj"
+        streetsmw: "streetsmw"
+    stress:
+      description: "stress"
+    strhoop:
+      description: "strhoop"
+    strider:
+      description: "strider"
+      children:
+        striderj: "striderj"
+        striderjr: "striderjr"
+        striderua: "striderua"
+        strideruc: "strideruc"
+    strkfgtr:
+      description: "strkfgtr"
+      children:
+        strkfgtrj: "strkfgtrj"
+    subroc3d:
+      description: "subroc3d"
+    suikoenb:
+      description: "suikoenb"
+    superchs:
+      description: "superchs"
+      children:
+        superchsj: "superchsj"
+        superchsp: "superchsp"
+        superchsp2: "superchsp2"
+        superchsu: "superchsu"
+    superman:
+      description: "superman"
+      children:
+        supermanj: "supermanj"
+        supermanu: "supermanu"
+    superspy:
+      description: "superspy"
+    suprleag:
+      description: "suprleag"
+    suprmrio:
+      description: "suprmrio"
+      children:
+        skatekds: "skatekds"
+        suprmrioa: "suprmrioa"
+        suprmriob2: "suprmriob2"
+        suprmriobl: "suprmriobl"
+    suprridr:
+      description: "suprridr"
+    supxevs:
+      description: "supxevs"
+    svc:
+      description: "svc"
+      children:
+        svcboot: "svcboot"
+        svcplus: "svcplus"
+        svcplusa: "svcplusa"
+        svcsplus: "svcsplus"
+    svf:
+      description: "svf"
+      children:
+        jleague: "jleague"
+        jleagueo: "jleagueo"
+        svfo: "svfo"
+        svs: "svs"
+    swa:
+      description: "swa"
+      children:
+        swaj: "swaj"
+    swat:
+      description: "swat"
+    swinggal:
+      description: "swinggal"
+    swtrilgy:
+      description: "swtrilgy"
+      children:
+        swtrilgya: "swtrilgya"
+    syvalion:
+      description: "syvalion"
+      children:
+        syvalionp: "syvalionp"
+        syvalionu: "syvalionu"
+        syvalionw: "syvalionw"
+    szaxxon:
+      description: "szaxxon"
+    tactcian:
+      description: "tactcian"
+      children:
+        tactcian2: "tactcian2"
+    taiwanmb:
+      description: "taiwanmb"
+    tantr:
+      description: "tantr"
+      children:
+        tantrkor: "tantrkor"
+    tcobra2:
+      description: "tcobra2"
+      children:
+        ktiger2: "ktiger2"
+        tcobra2u: "tcobra2u"
+    tdfever:
+      description: "tdfever"
+      children:
+        tdfever2: "tdfever2"
+        tdfever2b: "tdfever2b"
+        tdfeverj: "tdfeverj"
+    techbowl:
+      description: "techbowl"
+    teddybb:
+      description: "teddybb"
+    telmahjn:
+      description: "telmahjn"
+    terracre:
+      description: "terracre"
+      children:
+        terracrea: "terracrea"
+        terracren: "terracren"
+    terraf:
+      description: "terraf"
+      children:
+        terrafb: "terrafb"
+        terrafj: "terrafj"
+        terrafjb: "terrafjb"
+        terrafu: "terrafu"
+        terrafua: "terrafua"
+    tetris:
+      description: "tetris"
+      children:
+        tetris1: "tetris1"
+        tetris1d: "tetris1d"
+        tetris2: "tetris2"
+        tetris2d: "tetris2d"
+        tetris3: "tetris3"
+        tetris3d: "tetris3d"
+        tetrisbl: "tetrisbl"
+        tetrisse: "tetrisse"
+        tetrist: "tetrist"
+        tetrista: "tetrista"
+        tetristh: "tetristh"
+    tfrceac:
+      description: "tfrceac"
+      children:
+        tfrceacj: "tfrceacj"
+        tfrceacjpb: "tfrceacjpb"
+    thndrbld:
+      description: "thndrbld"
+      children:
+        thndrbld1: "thndrbld1"
+    threeds:
+      description: "threeds"
+      children:
+        galds: "galds"
+        threedsa: "threedsa"
+    thundfox:
+      description: "thundfox"
+      children:
+        thundfoxj: "thundfoxj"
+        thundfoxu: "thundfoxu"
+    tigeroad:
+      description: "tigeroad"
+      children:
+        toramich: "toramich"
+    timeplt:
+      description: "timeplt"
+      children:
+        spaceplt: "spaceplt"
+        spaceplta: "spaceplta"
+        timeplta: "timeplta"
+        timepltc: "timepltc"
+    timescan:
+      description: "timescan"
+      children:
+        timescan1: "timescan1"
+        timescan3: "timescan3"
+    timesold:
+      description: "timesold"
+      children:
+        btlfield: "btlfield"
+        btlfieldb: "btlfieldb"
+        timesold1: "timesold1"
+    timetunl:
+      description: "timetunl"
+    titlef:
+      description: "titlef"
+      children:
+        titlefj: "titlefj"
+        titlefu: "titlefu"
+    tkoboxng:
+      description: "tkoboxng"
+    tnextspc:
+      description: "tnextspc"
+      children:
+        tnextspc2: "tnextspc2"
+        tnextspcj: "tnextspcj"
+    tnk3:
+      description: "tnk3"
+      children:
+        tnk3b: "tnk3b"
+        tnk3j: "tnk3j"
+    tnzs:
+      description: "tnzs"
+      children:
+        tnzsj: "tnzsj"
+        tnzsjo: "tnzsjo"
+        tnzso: "tnzso"
+        tnzsoa: "tnzsoa"
+        tnzsop: "tnzsop"
+        tnzsuo: "tnzsuo"
+    togenkyo:
+      description: "togenkyo"
+    tokio:
+      description: "tokio"
+      children:
+        tokiob: "tokiob"
+        tokioo: "tokioo"
+        tokiou: "tokiou"
+    tokisens:
+      description: "tokisens"
+      children:
+        tokisensa: "tokisensa"
+    tokyogal:
+      description: "tokyogal"
+      children:
+        tokimbsj: "tokimbsj"
+    topgun:
+      description: "topgun"
+    tophuntr:
+      description: "tophuntr"
+    topland:
+      description: "topland"
+      children:
+        toplandj: "toplandj"
+    topskatr:
+      description: "topskatr"
+      children:
+        topskatrj: "topskatrj"
+        topskatru: "topskatru"
+        topskatruo: "topskatruo"
+    topspeed:
+      description: "topspeed"
+      children:
+        fullthrl: "fullthrl"
+        topspeedu: "topspeedu"
+    toryumon:
+      description: "toryumon"
+    toutrun:
+      description: "toutrun"
+      children:
+        toutrun1: "toutrun1"
+        toutrun2: "toutrun2"
+        toutrun3: "toutrun3"
+        toutrunj: "toutrunj"
+        toutrunj1: "toutrunj1"
+    tp84:
+      description: "tp84"
+      children:
+        tp84a: "tp84a"
+        tp84b: "tp84b"
+    tpgolf:
+      description: "tpgolf"
+    trackfld:
+      description: "trackfld"
+      children:
+        hipoly: "hipoly"
+        hyprolym: "hyprolym"
+        hyprolyma: "hyprolyma"
+        hyprolymb: "hyprolymb"
+        hyprolymba: "hyprolymba"
+        trackfldc: "trackfldc"
+        trackfldu: "trackfldu"
+    trally:
+      description: "trally"
+    tranqgun:
+      description: "tranqgun"
+    transfrm:
+      description: "transfrm"
+      children:
+        astrofl: "astrofl"
+    travrusa:
+      description: "travrusa"
+    travusa:
+      description: "travusa"
+      children:
+        motorace: "motorace"
+        mototour: "mototour"
+    triplew1:
+      description: "triplew1"
+    triplew2:
+      description: "triplew2"
+    troangel:
+      description: "troangel"
+      children:
+        newtangl: "newtangl"
+    trojan:
+      description: "trojan"
+      children:
+        trojana: "trojana"
+        trojanb: "trojanb"
+        trojanj: "trojanj"
+        trojanjo: "trojanjo"
+        trojanlt: "trojanlt"
+        trojanr: "trojanr"
+    trstar:
+      description: "trstar"
+      children:
+        prmtmfgt: "prmtmfgt"
+        prmtmfgto: "prmtmfgto"
+        trstarj: "trstarj"
+        trstaro: "trstaro"
+        trstaroj: "trstaroj"
+    tturf:
+      description: "tturf"
+      children:
+        tturfu: "tturfu"
+    tubep:
+      description: "tubep"
+      children:
+        tubepb: "tubepb"
+    turbo:
+      description: "turbo"
+      children:
+        turboa: "turboa"
+        turbob: "turbob"
+        turbobl: "turbobl"
+        turboc: "turboc"
+        turbod: "turbod"
+        turboe: "turboe"
+    turfmast:
+      description: "turfmast"
+    turtles:
+      description: "turtles"
+      children:
+        600: "600"
+        turpin: "turpin"
+        turpinnv: "turpinnv"
+        turpins: "turpins"
+    tutankhm:
+      description: "tutankhm"
+      children:
+        tutankhmb: "tutankhmb"
+        tutankhms: "tutankhms"
+    tvtcrst2:
+      description: "tvtcrst2"
+    twcup98:
+      description: "twcup98"
+      children:
+        twsoc98: "twsoc98"
+    twinbee:
+      description: "twinbee"
+    twinbeeb:
+      description: "twinbeeb"
+    twinhawk:
+      description: "twinhawk"
+      children:
+        daisenpu: "daisenpu"
+        twinhawku: "twinhawku"
+    twinqix:
+      description: "twinqix"
+    twinspri:
+      description: "twinspri"
+    twinsqua:
+      description: "twinsqua"
+    twsoc96:
+      description: "twsoc96"
+    uccops:
+      description: "uccops"
+      children:
+        uccopsar: "uccopsar"
+        uccopsaru: "uccopsaru"
+        uccopsj: "uccopsj"
+        uccopsu: "uccopsu"
+    uchuuai:
+      description: "uchuuai"
+    ufosensi:
+      description: "ufosensi"
+      children:
+        ufosensib: "ufosensib"
+    ultracin:
+      description: "ultracin"
+    ultramhm:
+      description: "ultramhm"
+    undrfire:
+      description: "undrfire"
+      children:
+        undrfirej: "undrfirej"
+        undrfireu: "undrfireu"
+    uniwars:
+      description: "uniwars"
+      children:
+        asideral: "asideral"
+        galemp: "galemp"
+        gteikoku: "gteikoku"
+        pajaroes: "pajaroes"
+        skyraidr: "skyraidr"
+        spacbat2: "spacbat2"
+        spacbatt: "spacbatt"
+        spacempr: "spacempr"
+    unsquad:
+      description: "unsquad"
+      children:
+        area88: "area88"
+        area88r: "area88r"
+    upndown:
+      description: "upndown"
+      children:
+        upndownu: "upndownu"
+    vangrd2:
+      description: "vangrd2"
+    vanguard:
+      description: "vanguard"
+      children:
+        vanguardc: "vanguardc"
+        vanguardg: "vanguardg"
+        vanguardj: "vanguardj"
+    vanilla:
+      description: "vanilla"
+      children:
+        finalbny: "finalbny"
+    varth:
+      description: "varth"
+      children:
+        varthj: "varthj"
+        varthjr: "varthjr"
+        varthr1: "varthr1"
+        varthu: "varthu"
+    vcop:
+      description: "vcop"
+      children:
+        vcopa: "vcopa"
+    vcop2:
+      description: "vcop2"
+    vf:
+      description: "vf"
+    vf2:
+      description: "vf2"
+      children:
+        vf2a: "vf2a"
+        vf2b: "vf2b"
+        vf2o: "vf2o"
+    vf3:
+      description: "vf3"
+      children:
+        vf3a: "vf3a"
+        vf3c: "vf3c"
+        vf3tb: "vf3tb"
+    vfkids:
+      description: "vfkids"
+    vfremix:
+      description: "vfremix"
+    vhunt2:
+      description: "vhunt2"
+      children:
+        vhunt2d: "vhunt2d"
+        vhunt2r1: "vhunt2r1"
+    victroad:
+      description: "victroad"
+      children:
+        dogosoke: "dogosoke"
+    viewpoin:
+      description: "viewpoin"
+      children:
+        viewpoinp: "viewpoinp"
+    vigilant:
+      description: "vigilant"
+      children:
+        vigilanta: "vigilanta"
+        vigilantb: "vigilantb"
+        vigilantc: "vigilantc"
+        vigilantd: "vigilantd"
+        vigilantg: "vigilantg"
+        vigilanto: "vigilanto"
+    viofight:
+      description: "viofight"
+      children:
+        viofightj: "viofightj"
+        viofightu: "viofightu"
+    vliner:
+      description: "vliner"
+      children:
+        vliner53: "vliner53"
+        vliner54: "vliner54"
+        vliner6e: "vliner6e"
+        vliner7e: "vliner7e"
+    vmahjong:
+      description: "vmahjong"
+    volfied:
+      description: "volfied"
+      children:
+        volfiedj: "volfiedj"
+        volfiedjo: "volfiedjo"
+        volfiedu: "volfiedu"
+        volfieduo: "volfieduo"
+    von:
+      description: "von"
+      children:
+        vonj: "vonj"
+        vonr: "vonr"
+        vonu: "vonu"
+    von2:
+      description: "von2"
+      children:
+        von254g: "von254g"
+        von2a: "von2a"
+        von2o: "von2o"
+    vr:
+      description: "vr"
+      children:
+        vformula: "vformula"
+    vs2:
+      description: "vs2"
+      children:
+        vs215: "vs215"
+        vs215o: "vs215o"
+    vs298:
+      description: "vs298"
+      children:
+        vs29815: "vs29815"
+    vs2v991:
+      description: "vs2v991"
+      children:
+        vs299: "vs299"
+        vs29915: "vs29915"
+        vs29915a: "vs29915a"
+        vs29915j: "vs29915j"
+        vs299a: "vs299a"
+        vs299j: "vs299j"
+    vsav:
+      description: "vsav"
+      children:
+        vsava: "vsava"
+        vsavb: "vsavb"
+        vsavd: "vsavd"
+        vsavh: "vsavh"
+        vsavj: "vsavj"
+        vsavu: "vsavu"
+    vsav2:
+      description: "vsav2"
+      children:
+        vsav2d: "vsav2d"
+    vsbball:
+      description: "vsbball"
+      children:
+        vsbballj: "vsbballj"
+        vsbballja: "vsbballja"
+        vsbballjb: "vsbballjb"
+    vsfdf:
+      description: "vsfdf"
+    vsgongf:
+      description: "vsgongf"
+      children:
+        ringfgt: "ringfgt"
+        ringfgta: "ringfgta"
+    vsgradus:
+      description: "vsgradus"
+    vsgshoe:
+      description: "vsgshoe"
+    vsmahjng:
+      description: "vsmahjng"
+    vspinbal:
+      description: "vspinbal"
+      children:
+        vspinbalj: "vspinbalj"
+    vsskykid:
+      description: "vsskykid"
+    vsslalom:
+      description: "vsslalom"
+    vssoccer:
+      description: "vssoccer"
+      children:
+        vssoccera: "vssoccera"
+    vstennis:
+      description: "vstennis"
+      children:
+        vstennisa: "vstennisa"
+        vstennisb: "vstennisb"
+    vstriker:
+      description: "vstriker"
+      children:
+        vstrikero: "vstrikero"
+    vulgus:
+      description: "vulgus"
+      children:
+        mach9: "mach9"
+        vulgusa: "vulgusa"
+        vulgusj: "vulgusj"
+    wakuwak7:
+      description: "wakuwak7"
+    wantsega:
+      description: "wantsega"
+    warriorb:
+      description: "warriorb"
+    wasafari:
+      description: "wasafari"
+    waterski:
+      description: "waterski"
+    waverunr:
+      description: "waverunr"
+    wb3:
+      description: "wb3"
+      children:
+        wb31: "wb31"
+        wb32: "wb32"
+        wb33: "wb33"
+        wb34: "wb34"
+        wb35: "wb35"
+    wbml:
+      description: "wbml"
+      children:
+        wbmljo: "wbmljo"
+        wbmlvc: "wbmlvc"
+    wboy:
+      description: "wboy"
+      children:
+        wboy2: "wboy2"
+        wboy3: "wboy3"
+        wboy6: "wboy6"
+        wboysys2: "wboysys2"
+        wboysys2a: "wboysys2a"
+    wcatcher:
+      description: "wcatcher"
+    wecleman:
+      description: "wecleman"
+      children:
+        weclemana: "weclemana"
+        weclemanb: "weclemanb"
+        weclemanc: "weclemanc"
+    wgp:
+      description: "wgp"
+      children:
+        wgp2: "wgp2"
+        wgpj: "wgpj"
+        wgpjoy: "wgpjoy"
+        wgpjoya: "wgpjoya"
+        wgpu: "wgpu"
+    wh1:
+      description: "wh1"
+    wh2:
+      description: "wh2"
+    wh2j:
+      description: "wh2j"
+    whp:
+      description: "whp"
+    willow:
+      description: "willow"
+      children:
+        willowj: "willowj"
+        willowu: "willowu"
+        willowuo: "willowuo"
+    wilytowr:
+      description: "wilytowr"
+      children:
+        atomboy: "atomboy"
+        atomboya: "atomboya"
+    wingwar:
+      description: "wingwar"
+      children:
+        wingwar360: "wingwar360"
+        wingwarj: "wingwarj"
+        wingwaru: "wingwaru"
+    winterht:
+      description: "winterht"
+    wiping:
+      description: "wiping"
+      children:
+        rugrats: "rugrats"
+    wizzquiz:
+      description: "wizzquiz"
+      children:
+        wizzquiza: "wizzquiza"
+    wjammers:
+      description: "wjammers"
+    wmatch:
+      description: "wmatch"
+    wof:
+      description: "wof"
+      children:
+        wofa: "wofa"
+        wofj: "wofj"
+        wofr1: "wofr1"
+        wofu: "wofu"
+    wofch:
+      description: "wofch"
+    worldwar:
+      description: "worldwar"
+    wpksoc:
+      description: "wpksoc"
+      children:
+        kftgoal: "kftgoal"
+    wrecking:
+      description: "wrecking"
+    wrestwar:
+      description: "wrestwar"
+      children:
+        wrestwar1: "wrestwar1"
+        wrestwar2: "wrestwar2"
+    wwallyj:
+      description: "wwallyj"
+      children:
+        wwallyja: "wwallyja"
+        wwallyja3p: "wwallyja3p"
+    wwanpanm:
+      description: "wwanpanm"
+    wwestern:
+      description: "wwestern"
+      children:
+        wwestern1: "wwestern1"
+    wwmarine:
+      description: "wwmarine"
+    wyvernf0:
+      description: "wyvernf0"
+      children:
+        wyvernf0a: "wyvernf0a"
+    xmcota:
+      description: "xmcota"
+      children:
+        xmcotaa: "xmcotaa"
+        xmcotaar1: "xmcotaar1"
+        xmcotaar2: "xmcotaar2"
+        xmcotab: "xmcotab"
+        xmcotah: "xmcotah"
+        xmcotahr1: "xmcotahr1"
+        xmcotaj: "xmcotaj"
+        xmcotaj1: "xmcotaj1"
+        xmcotaj2: "xmcotaj2"
+        xmcotaj3: "xmcotaj3"
+        xmcotajr: "xmcotajr"
+        xmcotar1: "xmcotar1"
+        xmcotar1d: "xmcotar1d"
+        xmcotau: "xmcotau"
+    xmultipl:
+      description: "xmultipl"
+      children:
+        xmultiplm72: "xmultiplm72"
+    xmvsf:
+      description: "xmvsf"
+      children:
+        xmvsfa: "xmvsfa"
+        xmvsfar1: "xmvsfar1"
+        xmvsfar2: "xmvsfar2"
+        xmvsfar3: "xmvsfar3"
+        xmvsfb: "xmvsfb"
+        xmvsfh: "xmvsfh"
+        xmvsfj: "xmvsfj"
+        xmvsfjr1: "xmvsfjr1"
+        xmvsfjr2: "xmvsfjr2"
+        xmvsfjr3: "xmvsfjr3"
+        xmvsfr1: "xmvsfr1"
+        xmvsfu: "xmvsfu"
+        xmvsfu1d: "xmvsfu1d"
+        xmvsfur1: "xmvsfur1"
+        xmvsfur2: "xmvsfur2"
+    yattrmnp:
+      description: "yattrmnp"
+    yesnoj:
+      description: "yesnoj"
+    yiear:
+      description: "yiear"
+      children:
+        yiear2: "yiear2"
+        yieartf: "yieartf"
+    yosimoto:
+      description: "yosimoto"
+      children:
+        yosimotm: "yosimotm"
+    youjyudn:
+      description: "youjyudn"
+    yuyugogo:
+      description: "yuyugogo"
+    zaxxon:
+      description: "zaxxon"
+    zedblade:
+      description: "zedblade"
+    zerogun:
+      description: "zerogun"
+      children:
+        zeroguna: "zeroguna"
+        zerogunaj: "zerogunaj"
+        zerogunj: "zerogunj"
+    zintrckb:
+      description: "zintrckb"
+    znpwfv:
+      description: "znpwfv"
+      children:
+        znpwfvt: "znpwfvt"
+    zookeep:
+      description: "zookeep"
+      children:
+        zookeep2: "zookeep2"
+        zookeep3: "zookeep3"
+        zookeepbl: "zookeepbl"
+    zunkyou:
+      description: "zunkyou"
+    zupapa:
+      description: "zupapa"
 
 tag_structure:
   symbols:

--- a/tags.yml
+++ b/tags.yml
@@ -870,7 +870,154 @@ search:
         brand: "Endorsed by company or brand"
 
 compilation:
-    description: "Compilation of previously released games : ID"
+  description: "Compilation of previously released games"
+  subtag:
+    adamandeve:
+      description: "Adam and Eve"
+    babyboomer:
+      description: "Baby Boomer"
+    balloonmonster:
+      description: "Balloon Monster"
+    baseballpros:
+      description: "Baseball Pros"
+    bignosefreaksout:
+      description: "Big Nose Freaks Out"
+    bignosethecaveman:
+      description: "Big Nose the Caveman"
+    blackjack:
+      description: "Blackjack"
+    bmxsimulator:
+      description: "BMX Simulator"
+    boomerangkid:
+      description: "Boomerang Kid"
+    bombliss:
+      description: "Bombliss"
+    brushroller:
+      description: "Brush Roller"
+    challengeofthedragon:
+      description: "Challenge of the Dragon"
+    chiller:
+      description: "Chiller"
+    cjselephantantics:
+      description: "C.J.'s Elephant Antics"
+    cosmoscop:
+      description: "Cosmoscop"
+    crystalmines:
+      description: "Crystal Mines"
+    deathbots:
+      description: "Death Bots"
+    deathrace:
+      description: "Death Race"
+    donkeykong:
+      description: "Donkey Kong"
+    donkeykongjr:
+      description: "Donkey Kong Jr."
+    donkeykongjrnosansuuasobi:
+      description: "Donkey Kong Jr. No Sansuu Asobi"
+    doublestrike:
+      description: "Double Strike"
+    duckhunt:
+      description: "Duck Hunt"
+    dudeswithattitude:
+      description: "Dudes with Attitude"
+    f15citywar:
+      description: "F-15 City War"
+    f16renegade:
+      description: "F-16 Renegade"
+    fantasticdizzy:
+      description: "Fantastic Dizzy"
+    finalfantasy:
+      description: "Final Fantasy"
+    finalfantasy2:
+      description: "Final Fantasy II"
+    galacticcrusader:
+      description: "Galactic Crusader"
+    godizzygo:
+      description: "Go Dizzy Go"
+    krazykreatures:
+      description: "Krazy Kreatures"
+    kingneptunesadventure:
+      description: "King Neptune's Adventure"
+    linusspacehead:
+      description: "Linus Spacehead"
+    magiccarpet1001:
+      description: "Magic Carpet 1001"
+    mahjonggmen89satsusaretaol:
+      description: "Mahjong G-Men '89 Satsusareta OL"
+    masterchuandthedrunkardhu:
+      description: "Master Chu and the Drunkard Hu"
+    menacebeach:
+      description: "Menace Beach"
+    micromachines:
+      description: "Micro Machines"
+    moonranger:
+      description: "Moon Ranger"
+    nekketsukoukoudodgeballbusoccerhen:
+      description: "Nekketsu Kōkō Dodgeball Bu Soccer Hen"
+    ohpaipee:
+      description: "Oh Pai Pee"
+    operationsecretstorm:
+      description: "Operation Secret Storm"
+    pesterminatorthewesternexterminator:
+      description: "Pesterminator the Western Exterminator"
+    porter:
+      description: "Porter"
+    pradikusconflict:
+      description: "Pradikus Conflict"
+    protennis:
+      description: "Pro Tennis"
+    puzzleideatek:
+      description: "Puzzle Idea Tek"
+    pyramid1:
+      description: "Pyramid 1"
+    raid2020:
+      description: "Raid 2020"
+    radrackettennis:
+      description: "Rad Racquet Tennis"
+    robodemons:
+      description: "Robo Demons"
+    runningstadium:
+      description: "Running Stadium"
+    secretscoutinthetempleofdemise:
+      description: "Secret Scout in the Temple of Demise"
+    sesamestreet123:
+      description: "Sesame Street 123"
+    sesamestreetabc:
+      description: "Sesame Street ABC"
+    shockwave:
+      description: "Shockwave"
+    soccercm:
+      description: "Soccer CM"
+    soccersimulator:
+      description: "Soccer Simulator"
+    solitairenes:
+      description: "Solitaire NES"
+    stakkm:
+      description: "Stakk M"
+    stuntbuggies:
+      description: "Stunt Buggies"
+    superrobinhood:
+      description: "Super Robin Hood"
+    supermariobros:
+      description: "Super Mario Bros."
+      children:
+        supermariobros2: "Super Mario Bros. 2"
+        supermariobros3: "Super Mario Bros. 3"
+        yumekoujoudokidokipanic: "Yume Kōjō Doki Doki Panic"
+    tetris2:
+      description: "Tetris 2"
+    theadventuresofcaptaincomic:
+      description: "The Adventures of Captain Comic"
+    theultimatestuntman:
+      description: "The Ultimate Stuntman"
+    tilesoffate:
+      description: "Tiles of Fate"
+    treasureislanddizzy:
+      description: "Treasure Island Dizzy"
+    uschampionshipvball:
+      description: "US Championship V'Ball"
+    venicebeachvolleyball:
+      description: "Venice Beach Volleyball"
 
 reboxed:
   description: "Reboxed"


### PR DESCRIPTION
Reworked **tags.yml** for both compilation and mamerom tags. 
Added missing subtags and nested children, alphabetized entries, and improved tag descriptions for readability. 

This update needs a careful review to confirm the new tag structure and coverage.