### PR TITLE
chore(ci): migrate workflows to Node 24 for GitHub Actions

### DIFF
--- a/.github/workflows/deploy-retroseek.yml
+++ b/.github/workflows/deploy-retroseek.yml
@@ -13,6 +13,9 @@ on:
       - 'src/retroseek/**'
       - 'tags.yml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -16,6 +16,9 @@ on:
       - 'scripts/README_TEMPLATE.md'
       - 'tags.yml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   generate-readme:
     runs-on: ubuntu-latest
@@ -40,7 +43,7 @@ jobs:
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache pip packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -15,6 +15,9 @@ on:
       - 'tags.yml'
       - 'scripts/tag_guardian.py'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   generate-report:
     runs-on: ubuntu-latest
@@ -36,7 +39,7 @@ jobs:
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
           
       - name: Cache pip packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}


### PR DESCRIPTION
### Summary
This PR updates our CI workflows to be ready for Node.js 24 in GitHub Actions.

### What changed
- Added an environment setting to force JavaScript-based actions to run on Node.js 24.
- Upgraded cache action from v3 to v4 in the Python workflows.

### Why this change
GitHub Actions is deprecating Node.js 20.  
These updates prevent deprecation warnings and reduce the risk of future CI failures.

### Expected impact
- Fewer deprecation warnings in workflow runs.
- Better compatibility with upcoming GitHub Actions runner changes.
- No functional changes to game data or application logic.

### Validation
- Workflow files were updated and checked for syntax issues.
- Branch with these changes was pushed successfully.