### PR TITLE
feat: add tag skip support and simplify README template

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ GameDataBase project aims to provide the most detailed information about every v
 | **Developer** | Company/team that developed the game |
 | **Publisher** | Company that published/distributed the game |
 | **Tags** | Game classification tags using the defined taxonomy |
-| **MAME filename** | ROM filename as used in MAME, only for Arcade games |
 | **MD5 hash** | MD5 checksum of the game file |
 | **SHA1 hash** | SHA1 checksum of the game file |
 | **SHA256 hash** | SHA256 checksum of the game file |
@@ -39,7 +38,13 @@ GameDataBase uses a hierarchical tag system with up to three levels of depth:
 | 2     | `:`    | Subtag            | `#genre:sports`         |
 | 3     | `>`    | Children value    | `#genre:sports>wrestling` |
 
-Multiple tags and attributes can be combined. For example:
+Quick rules:
+
+- A game usually combines multiple tags, separated by spaces.
+- The most common base pattern in this dataset is `#genre + #players + #lang`.
+- The `>` level only applies to its immediate `:` subtag.
+
+Basic example:
 
 ```ts
 #genre:sports>wrestling #players:2:vs
@@ -50,18 +55,52 @@ This means: Wrestling sports game, 2 players, versus mode.
 Tag combinations examples:
 
 ```ts
-#genre:action>runandgun               // Action game with run and gun theme
-#genre:sports>soccer #players:2       // Soccer game for 2 players
-#genre:board>chess #input:joystick>4  // Chess game with 4-way joystick control  
-#genre:shmup>v #search:tate>cw        // Vertical shoot'em up in clockwise TATE mode
-#genre:puzzle>drop #players:2:vs      // Drop puzzle game with 2 players in versus mode
-#genre:adventure>survivalhorror       // Adventure game with survival horror elements
-#input:joystick>4:buttons>2           // 4-way joystick and 2 buttons
-#players:2:coop                       // 2 players cooperative
-#based:movie #lang:en                 // English game based on a movie
+#genre:action>platformer #players:1 #lang:en                            // Action platform game, single player, English language
+#genre:fighting #players:2:vs #lang:ja #input:joystick>8:buttons>2      // Fighting game, 2-player versus, Japanese, 8-way joystick and 2 buttons
+#genre:action>platformer #players:2:coop #lang:en #save:backup          // Action platform game, 2-player co-op, English, save backup support
+#genre:puzzle>drop #players:2:alt #lang:en #save:password               // Drop puzzle game, 2-player alternating, English, password save system
+#compatibility:gameboy>mono #addon:link>gamelinkcable #players:2:vs     // Original monochrome Game Boy mode, link cable accessory, 2-player versus
+#arcadeboard:sega>naomi #mameparent #mamerom:virtuatennis>epr-12345     // Sega NAOMI arcade board with MAME parent and dynamic ROM/subfile reference
+#genre:shmup>v #search:tate>cw #players:1 #lang:ja                      // Vertical shoot'em up, clockwise TATE orientation, single player, Japanese
 ```
 
-The `>` level only applies to its immediate `:` subtag.
+## Skip Configuration
+
+Tag Guardian supports `skip:` as an opt-out flag for these two cases:
+
+<details>
+<summary><strong>1) Skip Subtags (main tag)</strong></summary>
+
+```yaml
+mamerom:
+  description: "Merged MAME ROM ZIP file > MAME ROM ZIP subfile"
+  skip:
+
+compilation:
+  description: "Compilation of previously released games : ID"
+  skip:
+```
+
+</details>
+
+<details>
+<summary><strong>2) Skip Subtag Childrens</strong></summary>
+
+```yaml
+input:
+  description: "Input system"
+  subtag:
+    joystick:
+      description: "Joystick"
+      skip:
+```
+
+</details>
+
+Behavior summary:
+
+- `skip` at main tag level skips subtag and children validation for that main tag.
+- `skip` at subtag level skips children validation for that specific subtag.
 
 
 ---

--- a/scripts/README_TEMPLATE.md
+++ b/scripts/README_TEMPLATE.md
@@ -19,7 +19,6 @@ GameDataBase project aims to provide the most detailed information about every v
 | **Developer** | Company/team that developed the game |
 | **Publisher** | Company that published/distributed the game |
 | **Tags** | Game classification tags using the defined taxonomy |
-| **MAME filename** | ROM filename as used in MAME, only for Arcade games |
 | **MD5 hash** | MD5 checksum of the game file |
 | **SHA1 hash** | SHA1 checksum of the game file |
 | **SHA256 hash** | SHA256 checksum of the game file |
@@ -39,7 +38,13 @@ GameDataBase uses a hierarchical tag system with up to three levels of depth:
 | 2     | `:`    | Subtag            | `#genre:sports`         |
 | 3     | `>`    | Children value    | `#genre:sports>wrestling` |
 
-Multiple tags and attributes can be combined. For example:
+Quick rules:
+
+- A game usually combines multiple tags, separated by spaces.
+- The most common base pattern in this dataset is `#genre + #players + #lang`.
+- The `>` level only applies to its immediate `:` subtag.
+
+Basic example:
 
 ```ts
 #genre:sports>wrestling #players:2:vs
@@ -50,18 +55,52 @@ This means: Wrestling sports game, 2 players, versus mode.
 Tag combinations examples:
 
 ```ts
-#genre:action>runandgun               // Action game with run and gun theme
-#genre:sports>soccer #players:2       // Soccer game for 2 players
-#genre:board>chess #input:joystick>4  // Chess game with 4-way joystick control  
-#genre:shmup>v #search:tate>cw        // Vertical shoot'em up in clockwise TATE mode
-#genre:puzzle>drop #players:2:vs      // Drop puzzle game with 2 players in versus mode
-#genre:adventure>survivalhorror       // Adventure game with survival horror elements
-#input:joystick>4:buttons>2           // 4-way joystick and 2 buttons
-#players:2:coop                       // 2 players cooperative
-#based:movie #lang:en                 // English game based on a movie
+#genre:action>platformer #players:1 #lang:en                            // Action platform game, single player, English language
+#genre:fighting #players:2:vs #lang:ja #input:joystick>8:buttons>2      // Fighting game, 2-player versus, Japanese, 8-way joystick and 2 buttons
+#genre:action>platformer #players:2:coop #lang:en #save:backup          // Action platform game, 2-player co-op, English, save backup support
+#genre:puzzle>drop #players:2:alt #lang:en #save:password               // Drop puzzle game, 2-player alternating, English, password save system
+#compatibility:gameboy>mono #addon:link>gamelinkcable #players:2:vs     // Original monochrome Game Boy mode, link cable accessory, 2-player versus
+#arcadeboard:sega>naomi #mameparent #mamerom:virtuatennis>epr-12345     // Sega NAOMI arcade board with MAME parent and dynamic ROM/subfile reference
+#genre:shmup>v #search:tate>cw #players:1 #lang:ja                      // Vertical shoot'em up, clockwise TATE orientation, single player, Japanese
 ```
 
-The `>` level only applies to its immediate `:` subtag.
+## Skip Configuration
+
+Tag Guardian supports `skip:` as an opt-out flag for these two cases:
+
+<details>
+<summary><strong>1) Skip Subtags (main tag)</strong></summary>
+
+```yaml
+mamerom:
+  description: "Merged MAME ROM ZIP file > MAME ROM ZIP subfile"
+  skip:
+
+compilation:
+  description: "Compilation of previously released games : ID"
+  skip:
+```
+
+</details>
+
+<details>
+<summary><strong>2) Skip Subtag Childrens</strong></summary>
+
+```yaml
+input:
+  description: "Input system"
+  subtag:
+    joystick:
+      description: "Joystick"
+      skip:
+```
+
+</details>
+
+Behavior summary:
+
+- `skip` at main tag level skips subtag and children validation for that main tag.
+- `skip` at subtag level skips children validation for that specific subtag.
 
 
 ---

--- a/scripts/tag_guardian.py
+++ b/scripts/tag_guardian.py
@@ -107,13 +107,20 @@ def validate_main_category(main_category: str, tags_definitions: dict) -> list:
 def validate_subtag_groups(subtag_groups: list, main_category: str, tags_definitions: dict) -> list:
     """Validate all subtag groups after the main category"""
     errors = []
+    category_definition = tags_definitions.get(main_category, {})
+
+    # Skip full branch validation for this main tag if requested in tags.yml.
+    if isinstance(category_definition, dict) and 'skip' in category_definition:
+        return errors
+
+    category_subtags = category_definition.get('subtag', {})
+
     for subtag_group in subtag_groups:
         subtag_parts = subtag_group.split('>')
         if not subtag_parts:
             continue
 
         subtag_name = subtag_parts[0].split(':')[0]
-        category_subtags = tags_definitions[main_category].get('subtag', {})
         errors.extend(validate_subtags(subtag_parts[0], category_subtags, main_category))
         if len(subtag_parts) > 1:
             errors.extend(validate_children(subtag_parts[1:], subtag_name, category_subtags, main_category))
@@ -132,8 +139,16 @@ def validate_subtags(subtag_group: str, category_subtags: dict, main_category: s
 def validate_children(children: list, subtag_name: str, category_subtags: dict, main_category: str) -> list:
     """Validate each child in the subtag group"""
     errors = []
-    if subtag_name in category_subtags and 'children' in category_subtags[subtag_name]:
-        valid_children = category_subtags[subtag_name]['children']
+    if not isinstance(category_subtags, dict):
+        return errors
+
+    subtag_definition = category_subtags.get(subtag_name)
+    if isinstance(subtag_definition, dict) and 'skip' in subtag_definition:
+        return errors
+
+    if isinstance(subtag_definition, dict) and 'children' in subtag_definition:
+        valid_children = subtag_definition['children']
+
         for child in children:
             if child not in valid_children:
                 errors.append((f"Invalid child: '{child}' for '{main_category}:{subtag_name}'", None))


### PR DESCRIPTION
## Summary
This PR improves Tag Guardian skip behavior and updates the README template in a simple way.

## What changed
- Add support to skip validation for a full main tag when `skip:` is set.
  - Example: `mamerom`, `compilation`
- Add support to skip children validation for a specific subtag when `skip:` is set.
  - Example: `input > joystick`
- Update `scripts/README_TEMPLATE.md` with a clearer tags guide and practical examples.
- Remove `MAME filename` from `scripts/README_TEMPLATE.md` because this field no longer exists.

## Skip examples (from README template)
```yaml
mamerom:
  description: "Merged MAME ROM ZIP file > MAME ROM ZIP subfile"
  skip:

compilation:
  description: "Compilation of previously released games : ID"
  skip:
```

```yaml
input:
  description: "Input system"
  subtag:
    joystick:
      description: "Joystick"
      skip:
```

## Related issues
Closes #87
Closes #79
