### PR TITLE
fix(tag-guardian): improve artifact summary links and report readability

### DIFF
--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -67,8 +67,8 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('tag_guardian_report.md', 'utf8');
-              const runId = process.env.GITHUB_RUN_ID;
-              const repository = process.env.GITHUB_REPOSITORY;
+            const runId = process.env.GITHUB_RUN_ID;
+            const repository = process.env.GITHUB_REPOSITORY;
 
             const toAnchorId = (reportPath) => {
               const fileName = reportPath.split('/').pop() || reportPath;
@@ -77,27 +77,98 @@ jobs:
               return `report-${safe}`;
             };
 
+            const extractCount = (content) => (content.match(/^\|\s*\d+\s*\|/gm) || []).length;
+
+            const stemToCsvName = (fileName) => {
+              const stem = fileName.replace(/\.md$/i, '');
+              return stem
+                .replace(/_errors$/i, '')
+                .replace(/_warnings$/i, '') + '.csv';
+            };
+
+            const cleanDetailContent = (content) => {
+              return content
+                .replace(/^#\s+.*\n+/m, '')
+                .trim();
+            };
+
+            const runUrl = `https://github.com/${repository}/actions/runs/${runId}`;
+
             const reportForSummary = report
+              .replace(/##\s+📑\s+Detailed Reports by File[\s\S]*$/g, '')
+              .replace(/##\s+Detailed Reports by File[\s\S]*$/g, '')
               .replace(/##\s+📑\s+Detailed Reports by File/g, '### Detailed Reports (Inline)')
               .replace(/##\s+Detailed Reports by File/g, '### Detailed Reports (Inline)')
               .replace(/\[([^\]]+)\]\((reports\/[^)]+)\)/g, (_match, label, reportPath) => {
-                  const anchor = toAnchorId(reportPath);
-                  return `[${label}](https://github.com/${repository}/actions/runs/${runId}#${anchor})`;
+                const anchor = toAnchorId(reportPath);
+                return `[${label}](${runUrl}#${anchor})`;
               });
 
             const detailFiles = fs.existsSync('reports')
               ? fs.readdirSync('reports').filter((name) => name.endsWith('.md')).sort()
               : [];
 
-            let detailsSection = '';
-            for (const fileName of detailFiles) {
+            const detailedReports = detailFiles.map((fileName) => {
               const relativePath = `reports/${fileName}`;
               const anchor = toAnchorId(relativePath);
-              const fileContent = fs.readFileSync(relativePath, 'utf8').trim();
-              detailsSection += `<a id="${anchor}"></a>\n`;
-              detailsSection += `<details>\n<summary><strong>${fileName}</strong></summary>\n\n`;
-              detailsSection += `${fileContent}\n\n`;
-              detailsSection += `</details>\n\n`;
+              const content = fs.readFileSync(relativePath, 'utf8').trim();
+              const count = extractCount(content);
+              const type = fileName.endsWith('_errors.md') ? 'errors' : 'warnings';
+              const csvName = stemToCsvName(fileName);
+              return {
+                fileName,
+                relativePath,
+                anchor,
+                content: cleanDetailContent(content),
+                type,
+                count,
+                csvName,
+                link: `${runUrl}#${anchor}`
+              };
+            });
+
+            const invalidReports = detailedReports.filter((r) => r.type === 'errors');
+            const warningReports = detailedReports.filter((r) => r.type === 'warnings');
+
+            let detailsSection = '### Detailed Reports (Inline)\n\n';
+
+            if (detailedReports.length === 0) {
+              detailsSection += 'No detailed markdown reports were generated in this run.\n';
+            } else {
+              detailsSection += '| Metric | Value |\n';
+              detailsSection += '|---|---:|\n';
+              detailsSection += `| Total detailed report files | ${detailedReports.length} |\n`;
+              detailsSection += `| Invalid tag report files | ${invalidReports.length} |\n`;
+              detailsSection += `| Warning report files | ${warningReports.length} |\n\n`;
+
+              detailsSection += '### ❌ Invalid Tags Reports\n\n';
+              if (invalidReports.length === 0) {
+                detailsSection += '- None\n\n';
+              } else {
+                for (const reportItem of invalidReports) {
+                  detailsSection += `- [📋 ${reportItem.csvName} (${reportItem.count} errors)](${reportItem.link})\n`;
+                }
+                detailsSection += '\n';
+              }
+
+              detailsSection += '### ⚠️ Warning Reports\n\n';
+              if (warningReports.length === 0) {
+                detailsSection += '- None\n\n';
+              } else {
+                for (const reportItem of warningReports) {
+                  detailsSection += `- [📋 ${reportItem.csvName} (${reportItem.count} warnings)](${reportItem.link})\n`;
+                }
+                detailsSection += '\n';
+              }
+
+              for (const reportItem of detailedReports) {
+                const typeLabel = reportItem.type === 'errors' ? 'Invalid Tags' : 'Warnings';
+                detailsSection += `<a id="${reportItem.anchor}"></a>\n`;
+                detailsSection += `<details>\n<summary><strong>${reportItem.fileName}</strong> · ${typeLabel}: ${reportItem.count}</summary>\n\n`;
+                detailsSection += `[⬆️ Back to run top](${runUrl})\n\n`;
+                detailsSection += `${reportItem.content}\n\n`;
+                detailsSection += `</details>\n\n`;
+              }
             }
 
             await core.summary

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -21,8 +21,6 @@ env:
 jobs:
   generate-report:
     runs-on: ubuntu-latest
-    outputs:
-      report_matrix: ${{ steps.build-matrix.outputs.report_matrix }}
     
     steps:
       - uses: actions/checkout@v4
@@ -55,36 +53,6 @@ jobs:
         run: |
           python -m scripts.tag_guardian
 
-      - name: Build report artifact matrix
-        id: build-matrix
-        run: |
-          python - <<'PY'
-          import glob
-          import json
-          import os
-          import re
-
-          def sanitize(name: str) -> str:
-              return re.sub(r'[^a-z0-9._-]+', '-', name.lower()).strip('-')
-
-          matrix = [
-              {
-                  'file_path': 'tag_guardian_report.md',
-                  'artifact_name': 'tag-guardian-main-report'
-              }
-          ]
-
-          for report_path in sorted(glob.glob('reports/*.md')):
-              stem = os.path.splitext(os.path.basename(report_path))[0]
-              matrix.append({
-                  'file_path': report_path,
-                  'artifact_name': f'tag-guardian-report-{sanitize(stem)}'
-              })
-
-          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
-              fh.write('report_matrix=' + json.dumps(matrix) + '\n')
-          PY
-          
       - name: Upload Reports Bundle
         uses: actions/upload-artifact@v4
         with:
@@ -93,37 +61,6 @@ jobs:
             tag_guardian_report.md
             reports/
 
-  upload-individual-reports:
-    needs: generate-report
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        report: ${{ fromJson(needs.generate-report.outputs.report_matrix) }}
-
-    steps:
-      - name: Download reports bundle
-        uses: actions/download-artifact@v4
-        with:
-          name: tag-guardian-report-bundle
-
-      - name: Upload individual report artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.report.artifact_name }}
-          path: ${{ matrix.report.file_path }}
-          if-no-files-found: error
-
-  publish-summary:
-    needs: [generate-report, upload-individual-reports]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download reports bundle
-        uses: actions/download-artifact@v4
-        with:
-          name: tag-guardian-report-bundle
-
       - name: Add Main Report to Summary
         uses: actions/github-script@v7
         with:
@@ -131,62 +68,39 @@ jobs:
             const fs = require('fs');
             const report = fs.readFileSync('tag_guardian_report.md', 'utf8');
 
-            const artifactNameForPath = (reportPath) => {
-              if (reportPath === 'tag_guardian_report.md') {
-                return 'tag-guardian-main-report';
-              }
+            const toAnchorId = (reportPath) => {
               const fileName = reportPath.split('/').pop() || reportPath;
               const stem = fileName.replace(/\.md$/i, '');
               const safe = stem.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
-              return `tag-guardian-report-${safe}`;
+              return `report-${safe}`;
             };
 
-            const runId = process.env.GITHUB_RUN_ID;
-            const repository = process.env.GITHUB_REPOSITORY;
-            const [owner, repo] = repository.split('/');
-
-            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
-              owner,
-              repo,
-              run_id: Number(runId),
-              per_page: 100
-            });
-
-            const artifactIdByName = new Map();
-            for (const artifact of artifacts) {
-              artifactIdByName.set(artifact.name, artifact.id);
-            }
-
             const reportForSummary = report.replace(/\[([^\]]+)\]\((reports\/[^)]+)\)/g, (_match, label, reportPath) => {
-              const artifactName = artifactNameForPath(reportPath);
-              const artifactId = artifactIdByName.get(artifactName);
-              if (!artifactId) {
-                return `${label} (missing artifact: ${artifactName})`;
-              }
-              const artifactUrl = `https://github.com/${repository}/actions/runs/${runId}/artifacts/${artifactId}`;
-              return `[${label}](${artifactUrl})`;
+              return `[${label}](#${toAnchorId(reportPath)})`;
             });
 
-            const individualArtifacts = artifacts
-              .filter((artifact) => artifact.name === 'tag-guardian-main-report' || artifact.name.startsWith('tag-guardian-report-'))
-              .sort((a, b) => a.name.localeCompare(b.name));
+            const detailFiles = fs.existsSync('reports')
+              ? fs.readdirSync('reports').filter((name) => name.endsWith('.md')).sort()
+              : [];
+
+            let detailsSection = '';
+            for (const fileName of detailFiles) {
+              const relativePath = `reports/${fileName}`;
+              const anchor = toAnchorId(relativePath);
+              const fileContent = fs.readFileSync(relativePath, 'utf8').trim();
+              detailsSection += `<a id="${anchor}"></a>\n`;
+              detailsSection += `<details>\n<summary><strong>${fileName}</strong></summary>\n\n`;
+              detailsSection += `${fileContent}\n\n`;
+              detailsSection += `</details>\n\n`;
+            }
 
             await core.summary
               .addHeading('Tag Guardian Validation Report')
               .addRaw(reportForSummary)
               .addEOL()
               .addSeparator()
-              .addHeading('Detailed Report Artifacts', 3);
-
-            if (individualArtifacts.length === 0) {
-              await core.summary.addRaw('No individual report artifacts were found.').write();
-              return;
-            }
-
-            await core.summary.addList(
-              individualArtifacts.map((artifact) => {
-                const artifactUrl = `https://github.com/${repository}/actions/runs/${runId}/artifacts/${artifact.id}`;
-                return `[${artifact.name}](${artifactUrl})`;
-              })
-            )
+              .addHeading('Detailed Reports (Inline)', 3)
+              .addRaw(
+                detailsSection || 'No detailed markdown reports were generated in this run.'
+              )
               .write();

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -53,21 +53,43 @@ jobs:
         run: |
           python -m scripts.tag_guardian
           
-      - name: Add Main Report to Summary
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const report = fs.readFileSync('tag_guardian_report.md', 'utf8');
-            await core.summary
-              .addHeading('Tag Guardian Validation Report')
-              .addRaw(report)
-              .write();
-
       - name: Upload All Reports
+        id: upload-reports
         uses: actions/upload-artifact@v4
         with:
           name: tag-guardian-reports
           path: |
             tag_guardian_report.md
             reports/
+
+      - name: Add Main Report to Summary
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_ID: ${{ steps.upload-reports.outputs.artifact-id }}
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('tag_guardian_report.md', 'utf8');
+            const reportForSummary = report.replace(/\[([^\]]+)\]\((reports\/[^)]+)\)/g, (_match, label, path) => {
+              return `${label} (artifact path: \`${path}\`)`;
+            });
+
+            const artifactId = process.env.ARTIFACT_ID;
+            const runId = process.env.GITHUB_RUN_ID;
+            const repository = process.env.GITHUB_REPOSITORY;
+            const artifactUrl = artifactId
+              ? `https://github.com/${repository}/actions/runs/${runId}/artifacts/${artifactId}`
+              : null;
+
+            await core.summary
+              .addHeading('Tag Guardian Validation Report')
+              .addRaw(reportForSummary)
+              .addEOL()
+              .addSeparator()
+              .addHeading('Detailed Reports Artifact', 3)
+              .addRaw(
+                artifactUrl
+                  ? `[Download tag-guardian-reports artifact](${artifactUrl})`
+                  : 'Artifact URL unavailable. Open the Artifacts section in this run.'
+              )
+              .write();

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -75,9 +75,12 @@ jobs:
               return `report-${safe}`;
             };
 
-            const reportForSummary = report.replace(/\[([^\]]+)\]\((reports\/[^)]+)\)/g, (_match, label, reportPath) => {
-              return `[${label}](#${toAnchorId(reportPath)})`;
-            });
+            const reportForSummary = report
+              .replace(/##\s+📑\s+Detailed Reports by File/g, '### Detailed Reports (Inline)')
+              .replace(/##\s+Detailed Reports by File/g, '### Detailed Reports (Inline)')
+              .replace(/\[([^\]]+)\]\((reports\/[^)]+)\)/g, (_match, label, reportPath) => {
+                return `[${label}](#${toAnchorId(reportPath)})`;
+              });
 
             const detailFiles = fs.existsSync('reports')
               ? fs.readdirSync('reports').filter((name) => name.endsWith('.md')).sort()

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -67,6 +67,8 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('tag_guardian_report.md', 'utf8');
+              const runId = process.env.GITHUB_RUN_ID;
+              const repository = process.env.GITHUB_REPOSITORY;
 
             const toAnchorId = (reportPath) => {
               const fileName = reportPath.split('/').pop() || reportPath;
@@ -79,7 +81,8 @@ jobs:
               .replace(/##\s+📑\s+Detailed Reports by File/g, '### Detailed Reports (Inline)')
               .replace(/##\s+Detailed Reports by File/g, '### Detailed Reports (Inline)')
               .replace(/\[([^\]]+)\]\((reports\/[^)]+)\)/g, (_match, label, reportPath) => {
-                return `[${label}](#${toAnchorId(reportPath)})`;
+                  const anchor = toAnchorId(reportPath);
+                  return `[${label}](https://github.com/${repository}/actions/runs/${runId}#${anchor})`;
               });
 
             const detailFiles = fs.existsSync('reports')
@@ -102,7 +105,6 @@ jobs:
               .addRaw(reportForSummary)
               .addEOL()
               .addSeparator()
-              .addHeading('Detailed Reports (Inline)', 3)
               .addRaw(
                 detailsSection || 'No detailed markdown reports were generated in this run.'
               )

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -21,6 +21,8 @@ env:
 jobs:
   generate-report:
     runs-on: ubuntu-latest
+    outputs:
+      report_matrix: ${{ steps.build-matrix.outputs.report_matrix }}
     
     steps:
       - uses: actions/checkout@v4
@@ -52,44 +54,139 @@ jobs:
       - name: Run Tag Guardian
         run: |
           python -m scripts.tag_guardian
+
+      - name: Build report artifact matrix
+        id: build-matrix
+        run: |
+          python - <<'PY'
+          import glob
+          import json
+          import os
+          import re
+
+          def sanitize(name: str) -> str:
+              return re.sub(r'[^a-z0-9._-]+', '-', name.lower()).strip('-')
+
+          matrix = [
+              {
+                  'file_path': 'tag_guardian_report.md',
+                  'artifact_name': 'tag-guardian-main-report'
+              }
+          ]
+
+          for report_path in sorted(glob.glob('reports/*.md')):
+              stem = os.path.splitext(os.path.basename(report_path))[0]
+              matrix.append({
+                  'file_path': report_path,
+                  'artifact_name': f'tag-guardian-report-{sanitize(stem)}'
+              })
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
+              fh.write('report_matrix=' + json.dumps(matrix) + '\n')
+          PY
           
-      - name: Upload All Reports
-        id: upload-reports
+      - name: Upload Reports Bundle
         uses: actions/upload-artifact@v4
         with:
-          name: tag-guardian-reports
+          name: tag-guardian-report-bundle
           path: |
             tag_guardian_report.md
             reports/
 
+  upload-individual-reports:
+    needs: generate-report
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        report: ${{ fromJson(needs.generate-report.outputs.report_matrix) }}
+
+    steps:
+      - name: Download reports bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: tag-guardian-report-bundle
+
+      - name: Upload individual report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.report.artifact_name }}
+          path: ${{ matrix.report.file_path }}
+          if-no-files-found: error
+
+  publish-summary:
+    needs: [generate-report, upload-individual-reports]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download reports bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: tag-guardian-report-bundle
+
       - name: Add Main Report to Summary
         uses: actions/github-script@v7
-        env:
-          ARTIFACT_ID: ${{ steps.upload-reports.outputs.artifact-id }}
         with:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('tag_guardian_report.md', 'utf8');
-            const reportForSummary = report.replace(/\[([^\]]+)\]\((reports\/[^)]+)\)/g, (_match, label, path) => {
-              return `${label} (artifact path: \`${path}\`)`;
-            });
 
-            const artifactId = process.env.ARTIFACT_ID;
+            const artifactNameForPath = (reportPath) => {
+              if (reportPath === 'tag_guardian_report.md') {
+                return 'tag-guardian-main-report';
+              }
+              const fileName = reportPath.split('/').pop() || reportPath;
+              const stem = fileName.replace(/\.md$/i, '');
+              const safe = stem.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+              return `tag-guardian-report-${safe}`;
+            };
+
             const runId = process.env.GITHUB_RUN_ID;
             const repository = process.env.GITHUB_REPOSITORY;
-            const artifactUrl = artifactId
-              ? `https://github.com/${repository}/actions/runs/${runId}/artifacts/${artifactId}`
-              : null;
+            const [owner, repo] = repository.split('/');
+
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner,
+              repo,
+              run_id: Number(runId),
+              per_page: 100
+            });
+
+            const artifactIdByName = new Map();
+            for (const artifact of artifacts) {
+              artifactIdByName.set(artifact.name, artifact.id);
+            }
+
+            const reportForSummary = report.replace(/\[([^\]]+)\]\((reports\/[^)]+)\)/g, (_match, label, reportPath) => {
+              const artifactName = artifactNameForPath(reportPath);
+              const artifactId = artifactIdByName.get(artifactName);
+              if (!artifactId) {
+                return `${label} (missing artifact: ${artifactName})`;
+              }
+              const artifactUrl = `https://github.com/${repository}/actions/runs/${runId}/artifacts/${artifactId}`;
+              return `[${label}](${artifactUrl})`;
+            });
+
+            const individualArtifacts = artifacts
+              .filter((artifact) => artifact.name === 'tag-guardian-main-report' || artifact.name.startsWith('tag-guardian-report-'))
+              .sort((a, b) => a.name.localeCompare(b.name));
 
             await core.summary
               .addHeading('Tag Guardian Validation Report')
               .addRaw(reportForSummary)
               .addEOL()
               .addSeparator()
-              .addHeading('Detailed Reports Artifact', 3)
-              .addRaw(
-                artifactUrl
-                  ? `[Download tag-guardian-reports artifact](${artifactUrl})`
-                  : 'Artifact URL unavailable. Open the Artifacts section in this run.'
-              )
+              .addHeading('Detailed Report Artifacts', 3);
+
+            if (individualArtifacts.length === 0) {
+              await core.summary.addRaw('No individual report artifacts were found.').write();
+              return;
+            }
+
+            await core.summary.addList(
+              individualArtifacts.map((artifact) => {
+                const artifactUrl = `https://github.com/${repository}/actions/runs/${runId}/artifacts/${artifact.id}`;
+                return `[${artifact.name}](${artifactUrl})`;
+              })
+            )
               .write();

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -84,99 +84,17 @@ jobs:
               return `report-${safe}`;
             };
 
-            const extractCount = (content) => (content.match(/^\|\s*\d+\s*\|/gm) || []).length;
-
-            const stemToCsvName = (fileName) => {
-              const stem = fileName.replace(/\.md$/i, '');
-              return stem
-                .replace(/_errors$/i, '')
-                .replace(/_warnings$/i, '') + '.csv';
-            };
-
-            const cleanDetailContent = (content) => {
-              return content
-                .replace(/^#\s+.*\n+/m, '')
-                .replace(/^##\s+❌\s+Invalid Tags Found\s*\n+/m, '')
-                .replace(/^##\s+⚠️\s+Warnings\s*\n+/m, '')
-                .replace(/^###\s+📄\s+.*\n+/m, '')
-                .trim();
-            };
-
             const runUrl = `https://github.com/${repository}/actions/runs/${runId}`;
 
             const reportForSummary = report
               .replace(/##\s+📑\s+Detailed Reports by File[\s\S]*$/g, '')
               .replace(/##\s+Detailed Reports by File[\s\S]*$/g, '')
-              .replace(/##\s+📑\s+Detailed Reports by File/g, '### Detailed Reports (Inline)')
-              .replace(/##\s+Detailed Reports by File/g, '### Detailed Reports (Inline)')
               .replace(/\[([^\]]+)\]\((reports\/[^)]+)\)/g, (_match, label, reportPath) => {
                 const anchor = toAnchorId(reportPath);
                 return `[${label}](${runUrl}#${anchor})`;
               });
 
-            const detailFiles = fs.existsSync('reports')
-              ? fs.readdirSync('reports').filter((name) => name.endsWith('.md')).sort()
-              : [];
-
-            const detailedReports = detailFiles.map((fileName) => {
-              const relativePath = `reports/${fileName}`;
-              const anchor = toAnchorId(relativePath);
-              const content = fs.readFileSync(relativePath, 'utf8').trim();
-              const count = extractCount(content);
-              const type = fileName.endsWith('_errors.md') ? 'errors' : 'warnings';
-              const csvName = stemToCsvName(fileName);
-              return {
-                fileName,
-                relativePath,
-                anchor,
-                content: cleanDetailContent(content),
-                type,
-                count,
-                csvName,
-                link: `${runUrl}#${anchor}`
-              };
-            });
-
-            const invalidReports = detailedReports.filter((r) => r.type === 'errors');
-            const warningReports = detailedReports.filter((r) => r.type === 'warnings');
-
-            invalidReports.sort((a, b) => a.csvName.localeCompare(b.csvName));
-            warningReports.sort((a, b) => a.csvName.localeCompare(b.csvName));
-
-            const renderCollapsibleGroup = (title, reports, typeLabel) => {
-              let block = `#### ${title}\n\n`;
-              if (reports.length === 0) {
-                block += '- None\n\n';
-                return block;
-              }
-
-              for (const reportItem of reports) {
-                block += `<a id="${reportItem.anchor}"></a>\n`;
-                block += `<details>\n<summary><strong>${reportItem.csvName}</strong> · ${typeLabel}: ${reportItem.count}</summary>\n\n`;
-                block += `${reportItem.content}\n\n`;
-                block += `</details>\n\n`;
-              }
-              return block;
-            };
-
-            let detailsSection = '';
-
-            if (detailedReports.length === 0) {
-              detailsSection += 'No detailed markdown reports were generated in this run.\n';
-            } else {
-              detailsSection += '### Detailed Reports (Inline)\n\n';
-              detailsSection += renderCollapsibleGroup('❌ Invalid Tags Reports', invalidReports, 'Invalid Tags');
-              detailsSection += renderCollapsibleGroup('⚠️ Warning Reports', warningReports, 'Warnings');
-            }
-
             await core.summary
               .addHeading('Tag Guardian Validation Report')
               .addRaw(reportForSummary)
-              .addEOL()
-              .addSeparator()
-              .addEOL()
-              .addRaw(
-                detailsSection || 'No detailed markdown reports were generated in this run.',
-                true
-              )
               .write();

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -89,6 +89,9 @@ jobs:
             const cleanDetailContent = (content) => {
               return content
                 .replace(/^#\s+.*\n+/m, '')
+                .replace(/^##\s+❌\s+Invalid Tags Found\s*\n+/m, '')
+                .replace(/^##\s+⚠️\s+Warnings\s*\n+/m, '')
+                .replace(/^###\s+📄\s+.*\n+/m, '')
                 .trim();
             };
 
@@ -130,42 +133,23 @@ jobs:
             const invalidReports = detailedReports.filter((r) => r.type === 'errors');
             const warningReports = detailedReports.filter((r) => r.type === 'warnings');
 
-            let detailsSection = '### Detailed Reports (Inline)\n\n';
+            const orderedReports = [...invalidReports, ...warningReports]
+              .sort((a, b) => {
+                if (a.type !== b.type) {
+                  return a.type === 'errors' ? -1 : 1;
+                }
+                return a.csvName.localeCompare(b.csvName);
+              });
+
+            let detailsSection = '';
 
             if (detailedReports.length === 0) {
               detailsSection += 'No detailed markdown reports were generated in this run.\n';
             } else {
-              detailsSection += '| Metric | Value |\n';
-              detailsSection += '|---|---:|\n';
-              detailsSection += `| Total detailed report files | ${detailedReports.length} |\n`;
-              detailsSection += `| Invalid tag report files | ${invalidReports.length} |\n`;
-              detailsSection += `| Warning report files | ${warningReports.length} |\n\n`;
-
-              detailsSection += '### ❌ Invalid Tags Reports\n\n';
-              if (invalidReports.length === 0) {
-                detailsSection += '- None\n\n';
-              } else {
-                for (const reportItem of invalidReports) {
-                  detailsSection += `- [📋 ${reportItem.csvName} (${reportItem.count} errors)](${reportItem.link})\n`;
-                }
-                detailsSection += '\n';
-              }
-
-              detailsSection += '### ⚠️ Warning Reports\n\n';
-              if (warningReports.length === 0) {
-                detailsSection += '- None\n\n';
-              } else {
-                for (const reportItem of warningReports) {
-                  detailsSection += `- [📋 ${reportItem.csvName} (${reportItem.count} warnings)](${reportItem.link})\n`;
-                }
-                detailsSection += '\n';
-              }
-
-              for (const reportItem of detailedReports) {
+              for (const reportItem of orderedReports) {
                 const typeLabel = reportItem.type === 'errors' ? 'Invalid Tags' : 'Warnings';
                 detailsSection += `<a id="${reportItem.anchor}"></a>\n`;
-                detailsSection += `<details>\n<summary><strong>${reportItem.fileName}</strong> · ${typeLabel}: ${reportItem.count}</summary>\n\n`;
-                detailsSection += `[⬆️ Back to run top](${runUrl})\n\n`;
+                detailsSection += `<details>\n<summary><strong>${reportItem.csvName}</strong> · ${typeLabel}: ${reportItem.count}</summary>\n\n`;
                 detailsSection += `${reportItem.content}\n\n`;
                 detailsSection += `</details>\n\n`;
               }

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Build artifact name
         id: artifact-meta
         run: |
-          safe_branch="${GITHUB_REF_NAME//\//-}"
+          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          safe_branch="${branch//\//-}"
           echo "bundle_name=tg-${safe_branch}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Reports Bundle

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -133,26 +133,33 @@ jobs:
             const invalidReports = detailedReports.filter((r) => r.type === 'errors');
             const warningReports = detailedReports.filter((r) => r.type === 'warnings');
 
-            const orderedReports = [...invalidReports, ...warningReports]
-              .sort((a, b) => {
-                if (a.type !== b.type) {
-                  return a.type === 'errors' ? -1 : 1;
-                }
-                return a.csvName.localeCompare(b.csvName);
-              });
+            invalidReports.sort((a, b) => a.csvName.localeCompare(b.csvName));
+            warningReports.sort((a, b) => a.csvName.localeCompare(b.csvName));
+
+            const renderCollapsibleGroup = (title, reports, typeLabel) => {
+              let block = `#### ${title}\n\n`;
+              if (reports.length === 0) {
+                block += '- None\n\n';
+                return block;
+              }
+
+              for (const reportItem of reports) {
+                block += `<a id="${reportItem.anchor}"></a>\n`;
+                block += `<details>\n<summary><strong>${reportItem.csvName}</strong> · ${typeLabel}: ${reportItem.count}</summary>\n\n`;
+                block += `${reportItem.content}\n\n`;
+                block += `</details>\n\n`;
+              }
+              return block;
+            };
 
             let detailsSection = '';
 
             if (detailedReports.length === 0) {
               detailsSection += 'No detailed markdown reports were generated in this run.\n';
             } else {
-              for (const reportItem of orderedReports) {
-                const typeLabel = reportItem.type === 'errors' ? 'Invalid Tags' : 'Warnings';
-                detailsSection += `<a id="${reportItem.anchor}"></a>\n`;
-                detailsSection += `<details>\n<summary><strong>${reportItem.csvName}</strong> · ${typeLabel}: ${reportItem.count}</summary>\n\n`;
-                detailsSection += `${reportItem.content}\n\n`;
-                detailsSection += `</details>\n\n`;
-              }
+              detailsSection += '### Detailed Reports (Inline)\n\n';
+              detailsSection += renderCollapsibleGroup('❌ Invalid Tags Reports', invalidReports, 'Invalid Tags');
+              detailsSection += renderCollapsibleGroup('⚠️ Warning Reports', warningReports, 'Warnings');
             }
 
             await core.summary

--- a/.github/workflows/tag-guardian.yml
+++ b/.github/workflows/tag-guardian.yml
@@ -53,10 +53,16 @@ jobs:
         run: |
           python -m scripts.tag_guardian
 
+      - name: Build artifact name
+        id: artifact-meta
+        run: |
+          safe_branch="${GITHUB_REF_NAME//\//-}"
+          echo "bundle_name=tg-${safe_branch}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+
       - name: Upload Reports Bundle
         uses: actions/upload-artifact@v4
         with:
-          name: tag-guardian-report-bundle
+          name: ${{ steps.artifact-meta.outputs.bundle_name }}
           path: |
             tag_guardian_report.md
             reports/
@@ -167,7 +173,9 @@ jobs:
               .addRaw(reportForSummary)
               .addEOL()
               .addSeparator()
+              .addEOL()
               .addRaw(
-                detailsSection || 'No detailed markdown reports were generated in this run.'
+                detailsSection || 'No detailed markdown reports were generated in this run.',
+                true
               )
               .write();

--- a/scripts/tag_guardian.py
+++ b/scripts/tag_guardian.py
@@ -632,8 +632,7 @@ def write_inline_detailed_reports(report_file, stats, file_results):
         report_file.write("- None\n\n")
     else:
         for file_result, file_errors in error_files:
-            games_str = f"{file_result.get('games', '?')} games"
-            report_file.write(f"<details>\n<summary><strong>{file_result['file']}</strong> · ❌ {len(file_errors)} invalid tag(s) · {games_str}</summary>\n\n")
+            report_file.write(f"<details>\n<summary><strong>{file_result['file']}</strong> · ❌ {len(file_errors)} invalid tag(s)</summary>\n\n")
             write_error_section(report_file, file_errors, [file_result])
             report_file.write("\n</details>\n\n")
 
@@ -642,9 +641,8 @@ def write_inline_detailed_reports(report_file, stats, file_results):
         report_file.write("- None\n\n")
     else:
         for file_result, file_warnings in warning_files:
-            games_str = f"{file_result.get('games', '?')} games"
             total_issues = sum(len(w['warnings']) for w in file_warnings)
-            report_file.write(f"<details>\n<summary><strong>{file_result['file']}</strong> · ⚠️ {total_issues} issue(s) in {len(file_warnings)} game(s) · {games_str}</summary>\n\n")
+            report_file.write(f"<details>\n<summary><strong>{file_result['file']}</strong> · ⚠️ {total_issues} issue(s) in {len(file_warnings)} game(s)</summary>\n\n")
             write_warning_section(report_file, file_warnings, [file_result])
             report_file.write("\n</details>\n\n")
 

--- a/scripts/tag_guardian.py
+++ b/scripts/tag_guardian.py
@@ -51,6 +51,14 @@ REGION_LIST = [
     "World"
 ]
 
+TITLE_COLUMN_ALIASES = [
+    "Screen title @ Exact",
+    "Title screen (exact)",
+    "Title (exact)",
+    "Title screen",
+    "Title"
+]
+
 
 # Simplified argument processing
 parser = argparse.ArgumentParser(description='Tag Guardian - Validate game tags in CSV files')
@@ -216,6 +224,27 @@ def validate_tags(tags_str, tags_definitions):
     tag_errors = repeated_tag_errors + tag_errors
 
     return tag_errors, warnings, valid_count, total_tags
+
+
+def normalize_cell_value(value):
+    """Normalize CSV cell values and ignore placeholders used in this dataset."""
+    if value is None or pd.isna(value):
+        return None
+
+    text = str(value).strip()
+    if not text or text in {'=', '-'}:
+        return None
+    return text
+
+
+def resolve_game_title(row: pd.Series) -> str:
+    """Resolve the best available game title using known column aliases."""
+    for column in TITLE_COLUMN_ALIASES:
+        if column in row.index:
+            normalized = normalize_cell_value(row[column])
+            if normalized:
+                return normalized
+    return 'Unknown'
 
 
 def validate_region(region_value):
@@ -439,13 +468,14 @@ def process_csv_file(file_path: str, tags_definitions: dict) -> tuple:
 
 def process_game_row(row: pd.Series, idx: int, file_path: str, tags_definitions: dict) -> tuple:
     """Process single game row and return results"""
-    game_title = row['Screen title @ Exact'] if 'Screen title @ Exact' in row else 'Unknown'
+    game_title = resolve_game_title(row)
 
     # Create internal row tracking without showing it in reports
     internal_id = f"{game_title}__row_{idx + 1}"  # Double underscore to avoid conflicts
     display_id = game_title  # Only show game title in reports
 
     tags_str = row['Tags']
+    tags_str_for_matching = tags_str if isinstance(tags_str, str) else ''
     tag_errors, warnings, valid_count, total_tags = validate_tags(tags_str, tags_definitions)
 
     # Validate region from REGION_LIST list
@@ -457,10 +487,13 @@ def process_game_row(row: pd.Series, idx: int, file_path: str, tags_definitions:
     # Ensure warnings are associated with the correct tag
     warning_details = []
     for warning in warnings:
-        related_tag = next((tag for tag in tags_str.split() if warning.lower() in tag.lower()), None)
+        if warning.startswith('Region not defined') or warning.startswith('Invalid region'):
+            related_tag = 'Column: Region'
+        else:
+            related_tag = extract_relevant_tag(tags_str_for_matching, warning)
         warning_details.append({
             'warning': warning,
-            'related_tag': related_tag or "Unknown"
+            'related_tag': related_tag or 'N/A'
         })
 
     game_stats = {

--- a/scripts/tag_guardian.py
+++ b/scripts/tag_guardian.py
@@ -5,7 +5,6 @@ import time
 import argparse
 import sys
 import platform
-import random
 from colorama import init, Fore, Style, AnsiToWin32
 
 # Initialize colorama for Windows support
@@ -469,9 +468,10 @@ def process_csv_file(file_path: str, tags_definitions: dict) -> tuple:
 def process_game_row(row: pd.Series, idx: int, file_path: str, tags_definitions: dict) -> tuple:
     """Process single game row and return results"""
     game_title = resolve_game_title(row)
+    file_name = os.path.basename(file_path)
 
-    # Create internal row tracking without showing it in reports
-    internal_id = f"{game_title}__row_{idx + 1}"  # Double underscore to avoid conflicts
+    # Include source file in the internal key so rows from different CSVs never collide.
+    internal_id = f"{file_name}__{game_title}__row_{idx + 1}"
     display_id = game_title  # Only show game title in reports
 
     tags_str = row['Tags']
@@ -745,6 +745,19 @@ def collect_unregistered_tags(all_errors):
     return [(tag, count, tag_suggestions[tag])
             for tag, count in sorted(tag_counts.items(), key=lambda x: x[1], reverse=True)]
 
+
+def format_percentage(part: int, whole: int) -> str:
+    """Format percentages with better precision for very small non-zero values."""
+    if whole <= 0:
+        return "0%"
+
+    value = (part / whole) * 100
+    if value == 0:
+        return "0%"
+    if value < 0.1:
+        return f"{value:.3f}%"
+    return f"{value:.1f}%"
+
 def write_header_stats(report_file, stats):
     """Write header statistics to report file"""
     # Common column headers for both tables
@@ -755,18 +768,18 @@ def write_header_stats(report_file, stats):
     report_file.write("### 🎮 Games Stats\n")
     report_file.write(header_format)
     report_file.write(separator)
-    report_file.write(f"| ✅ Valid Games | **{stats['valid_games']}** | `{stats['valid_games']/stats['total_games']*100:.1f}%` | 🟢 | No issues found |\n")
-    report_file.write(f"| ❌ Invalid Games | **{stats['games_with_errors']}** | `{stats['games_with_errors']/stats['total_games']*100:.1f}%` | 🔴 | Need fixes |\n")
-    report_file.write(f"| ⚠️ Warning Games | **{stats['games_with_warnings']}** | `{stats['games_with_warnings']/stats['total_games']*100:.1f}%` | 🟡 | Review suggested |\n")
+    report_file.write(f"| ✅ Valid Games | **{stats['valid_games']}** | `{format_percentage(stats['valid_games'], stats['total_games'])}` | 🟢 | No issues found |\n")
+    report_file.write(f"| ❌ Invalid Games | **{stats['games_with_errors']}** | `{format_percentage(stats['games_with_errors'], stats['total_games'])}` | 🔴 | Need fixes |\n")
+    report_file.write(f"| ⚠️ Warning Games | **{stats['games_with_warnings']}** | `{format_percentage(stats['games_with_warnings'], stats['total_games'])}` | 🟡 | Review suggested |\n")
     report_file.write(f"| 🎲 Total Processed | **{stats['total_games']}** | `100%` | ⚪ | Unique entries |\n\n")
 
     # Tags Statistics
     report_file.write("### 🏷️ Tags Stats\n")
     report_file.write(header_format)
     report_file.write(separator)
-    report_file.write(f"| ✅ Valid Tags | **{stats['valid_tags']}** | `{stats['valid_tags']/stats['total_tags']*100:.1f}%` | 🟢 | Correct format |\n")
-    report_file.write(f"| ❌ Invalid Tags | **{stats['invalid_tags']}** | `{stats['invalid_tags']/stats['total_tags']*100:.1f}%` | 🔴 | Format errors |\n")
-    report_file.write(f"| ⚠️ Warning Tags | **{stats['warnings_count']}** | `{stats['warnings_count']/stats['total_tags']*100:.1f}%` | 🟡 | Need review |\n")
+    report_file.write(f"| ✅ Valid Tags | **{stats['valid_tags']}** | `{format_percentage(stats['valid_tags'], stats['total_tags'])}` | 🟢 | Correct format |\n")
+    report_file.write(f"| ❌ Invalid Tags | **{stats['invalid_tags']}** | `{format_percentage(stats['invalid_tags'], stats['total_tags'])}` | 🔴 | Format errors |\n")
+    report_file.write(f"| ⚠️ Warning Tags | **{stats['warnings_count']}** | `{format_percentage(stats['warnings_count'], stats['total_tags'])}` | 🟡 | Need review |\n")
     report_file.write(f"| 📝 Total Tags | **{stats['total_tags']}** | `100%` | ⚪ | All entries |\n\n")
 
 def write_overview_section(report_file, stats):
@@ -829,7 +842,7 @@ def write_suggested_actions(report_file):
         description = details.get('description', 'No description available')
         subtags = details.get('subtag', {})
         example = (
-            f"#{category}:{random.choice(list(subtags.keys()))}"
+            f"#{category}:{sorted(subtags.keys())[0]}"
             if subtags else 'No example available'
         )
         report_file.write(f"| `#{category}` | {description} | `{example}` |\n")

--- a/scripts/tag_guardian.py
+++ b/scripts/tag_guardian.py
@@ -5,6 +5,7 @@ import time
 import argparse
 import sys
 import platform
+from datetime import datetime
 from colorama import init, Fore, Style, AnsiToWin32
 
 # Initialize colorama for Windows support
@@ -447,7 +448,7 @@ def process_csv_file(file_path: str, tags_definitions: dict) -> tuple:
 
     file_result = {
         'file': os.path.basename(file_path),
-        'valid': 0, 'total': 0, 'invalid': 0, 'warnings': 0
+        'valid': 0, 'total': 0, 'invalid': 0, 'warnings': 0, 'games': 0
     }
 
     file_errors = []
@@ -544,6 +545,7 @@ def update_file_stats(file_result: dict, game_stats: dict):
         file_result['invalid'] = file_result['total'] - file_result['valid']
         # Accumulate warnings instead of overwriting
         file_result['warnings'] += stats['warnings_count']
+        file_result['games'] += 1
 
 def generate_markdown_report(stats: dict, file_results: list, file_path: str, args):
     """Generate markdown report with given statistics based on command line arguments"""
@@ -572,12 +574,15 @@ def generate_markdown_report(stats: dict, file_results: list, file_path: str, ar
 
     # Generate new reports
     with open(file_path, 'w', encoding='utf-8') as report_file:
+        stats['generated_at'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        stats['files_with_issues'] = sum(
+            1 for r in file_results if r['invalid'] > 0 or r['warnings'] > 0
+        )
         # Write header and basic sections
         write_main_report(report_file, stats, file_results, args)
 
         # List of detailed reports
         if not args.no_errors or not args.no_warnings:
-            write_detailed_reports_index(report_file, stats, file_results)
             write_inline_detailed_reports(report_file, stats, file_results)
 
         # Generate individual reports by file
@@ -609,7 +614,7 @@ def write_detailed_reports_index(report_file, stats, file_results):
 
 def write_inline_detailed_reports(report_file, stats, file_results):
     """Write the detailed per-file reports inline in the main markdown report."""
-    report_file.write("### Detailed Reports (Inline)\n\n")
+    report_file.write("\n## 📑 Detailed Reports\n\n")
 
     error_files = []
     warning_files = []
@@ -622,27 +627,42 @@ def write_inline_detailed_reports(report_file, stats, file_results):
         if file_warnings:
             warning_files.append((file_result, file_warnings))
 
-    report_file.write("#### ❌ Invalid Tags Reports\n\n")
+    report_file.write("### ❌ Invalid Tags\n\n")
     if not error_files:
         report_file.write("- None\n\n")
     else:
         for file_result, file_errors in error_files:
-            report_file.write(f"<details>\n<summary><strong>{file_result['file']}</strong> · Invalid Tags: {len(file_errors)}</summary>\n\n")
+            games_str = f"{file_result.get('games', '?')} games"
+            report_file.write(f"<details>\n<summary><strong>{file_result['file']}</strong> · ❌ {len(file_errors)} invalid tag(s) · {games_str}</summary>\n\n")
             write_error_section(report_file, file_errors, [file_result])
             report_file.write("\n</details>\n\n")
 
-    report_file.write("#### ⚠️ Warning Reports\n\n")
+    report_file.write("### ⚠️ Warnings\n\n")
     if not warning_files:
         report_file.write("- None\n\n")
     else:
         for file_result, file_warnings in warning_files:
-            report_file.write(f"<details>\n<summary><strong>{file_result['file']}</strong> · Warnings: {len(file_warnings)}</summary>\n\n")
+            games_str = f"{file_result.get('games', '?')} games"
+            total_issues = sum(len(w['warnings']) for w in file_warnings)
+            report_file.write(f"<details>\n<summary><strong>{file_result['file']}</strong> · ⚠️ {total_issues} issue(s) in {len(file_warnings)} game(s) · {games_str}</summary>\n\n")
             write_warning_section(report_file, file_warnings, [file_result])
             report_file.write("\n</details>\n\n")
 
 def write_main_report(report_file, stats, file_results, args):
     """Write main sections of the report"""
     report_file.write("# 📊 Tag Guardian Report\n\n")
+
+    # Health summary callout block
+    health_pct = format_percentage(stats['valid_games'], stats['total_games'])
+    if stats['games_with_errors'] == 0 and stats['games_with_warnings'] == 0:
+        health_icon, health_label = "🟢", "Excellent"
+    elif stats['games_with_errors'] == 0:
+        health_icon, health_label = "🟡", "Good — warnings present"
+    else:
+        health_icon, health_label = "🔴", "Needs Attention"
+    report_file.write(f"> **Database Health:** {health_icon} **{health_pct}** clean games — {health_label}  \n")
+    report_file.write(f"> 📅 Generated: `{stats['generated_at']}`  \n")
+    report_file.write(f"> 📁 `{stats['files_processed']}` files processed · `{stats['files_with_issues']}` with issues\n\n")
 
     if not args.no_stats and not args.compact:
         write_header_stats(report_file, stats)
@@ -814,8 +834,7 @@ def write_header_stats(report_file, stats):
     report_file.write(separator)
     report_file.write(f"| ✅ Valid Tags | **{stats['valid_tags']}** | `{format_percentage(stats['valid_tags'], stats['total_tags'])}` | 🟢 | Correct format |\n")
     report_file.write(f"| ❌ Invalid Tags | **{stats['invalid_tags']}** | `{format_percentage(stats['invalid_tags'], stats['total_tags'])}` | 🔴 | Format errors |\n")
-    report_file.write(f"| ⚠️ Warning Tags | **{stats['warnings_count']}** | `{format_percentage(stats['warnings_count'], stats['total_tags'])}` | 🟡 | Need review |\n")
-    report_file.write(f"| 📝 Total Tags | **{stats['total_tags']}** | `100%` | ⚪ | All entries |\n\n")
+    report_file.write(f"| 📝 Total Tags | **{stats['total_tags']}** | `100%` | ⚪ | All tag entries |\n\n")
 
 def write_overview_section(report_file, stats):
     """Write overview section to report file"""
@@ -832,11 +851,19 @@ def write_overview_section(report_file, stats):
 def write_validation_results(report_file, file_results):
     """Write validation results to report file"""
     report_file.write("### 📊 Validation Results\n")
-    report_file.write("_Note: Total Tags are the non-unique Individual tags in each file_\n\n")
-    report_file.write("| 📁 File | ✅ Valid | ❌ Invalid | ⚠️ Warnings | 📝 Total |\n")
-    report_file.write("|---------|-----------|------------|-------------|----------|\n")
-    for result in file_results:
-        report_file.write(f"| `{result['file']}` | **{result['valid']}** | **{result['invalid']}** | **{result['warnings']}** | {result['total']} |\n")
+    report_file.write("_Tag columns count individual tag entries per file. Issues column counts game-level validation flags._\n\n")
+    report_file.write("| 🚦 | 📁 File | 🎮 Games | ✅ Valid Tags | ❌ Invalid Tags | ⚠️ Issues | 📝 Total Tags |\n")
+    report_file.write("|---|---------|---------|-------------|----------------|----------|-------------|\n")
+    sorted_results = sorted(file_results, key=lambda r: (-r['invalid'], -r['warnings'], r['file']))
+    for result in sorted_results:
+        if result['invalid'] > 0:
+            status = "🔴"
+        elif result['warnings'] > 0:
+            status = "🟡"
+        else:
+            status = "🟢"
+        games_count = result.get('games', '-')
+        report_file.write(f"| {status} | `{result['file']}` | {games_count} | **{result['valid']}** | **{result['invalid']}** | **{result['warnings']}** | {result['total']} |\n")
 
 def write_suggested_actions(report_file):
     """Write suggested actions to report file"""
@@ -876,10 +903,9 @@ def write_suggested_actions(report_file):
     for category, details in tags_definitions.items():
         description = details.get('description', 'No description available')
         subtags = details.get('subtag', {})
-        example = (
-            f"#{category}:{sorted(subtags.keys())[0]}"
-            if subtags else 'No example available'
-        )
+        if not subtags:
+            continue
+        example = f"#{category}:{sorted(subtags.keys())[0]}"
         report_file.write(f"| `#{category}` | {description} | `{example}` |\n")
 
     report_file.write("\n")
@@ -923,7 +949,7 @@ def write_suggested_actions(report_file):
 
 def write_unregistered_tags(report_file, unregistered_tags):
     """Write unregistered tags section to report file"""
-    report_file.write("\n## Unregistered Tags\n")
+    report_file.write("\n## 🔍 Unregistered Tags\n")
     report_file.write("| Tag | Usage Count | Suggestion |\n")
     report_file.write("|-----|-------------|------------|\n")
     for tag, count, suggestion in unregistered_tags:

--- a/scripts/tag_guardian.py
+++ b/scripts/tag_guardian.py
@@ -578,6 +578,7 @@ def generate_markdown_report(stats: dict, file_results: list, file_path: str, ar
         # List of detailed reports
         if not args.no_errors or not args.no_warnings:
             write_detailed_reports_index(report_file, stats, file_results)
+            write_inline_detailed_reports(report_file, stats, file_results)
 
         # Generate individual reports by file
         for file_result in file_results:
@@ -604,6 +605,40 @@ def write_detailed_reports_index(report_file, stats, file_results):
             csv_name = os.path.splitext(file_result['file'])[0]
             report_file.write(f"- [📋 {file_result['file']} ({len(file_warnings)} warnings)](reports/{csv_name}_warnings.md)\n")
     report_file.write("\n")
+
+
+def write_inline_detailed_reports(report_file, stats, file_results):
+    """Write the detailed per-file reports inline in the main markdown report."""
+    report_file.write("### Detailed Reports (Inline)\n\n")
+
+    error_files = []
+    warning_files = []
+    for file_result in file_results:
+        file_errors = [e for e in stats['errors'] if e['file'] == file_result['file']]
+        if file_errors:
+            error_files.append((file_result, file_errors))
+
+        file_warnings = [w for w in stats['warnings'] if w['file'] == file_result['file']]
+        if file_warnings:
+            warning_files.append((file_result, file_warnings))
+
+    report_file.write("#### ❌ Invalid Tags Reports\n\n")
+    if not error_files:
+        report_file.write("- None\n\n")
+    else:
+        for file_result, file_errors in error_files:
+            report_file.write(f"<details>\n<summary><strong>{file_result['file']}</strong> · Invalid Tags: {len(file_errors)}</summary>\n\n")
+            write_error_section(report_file, file_errors, [file_result])
+            report_file.write("\n</details>\n\n")
+
+    report_file.write("#### ⚠️ Warning Reports\n\n")
+    if not warning_files:
+        report_file.write("- None\n\n")
+    else:
+        for file_result, file_warnings in warning_files:
+            report_file.write(f"<details>\n<summary><strong>{file_result['file']}</strong> · Warnings: {len(file_warnings)}</summary>\n\n")
+            write_warning_section(report_file, file_warnings, [file_result])
+            report_file.write("\n</details>\n\n")
 
 def write_main_report(report_file, stats, file_results, args):
     """Write main sections of the report"""


### PR DESCRIPTION
## Summary
This PR improves the Tag Guardian workflow summary and makes the report easier to read.

## Changes
- Added a stable reports artifact upload and cleaner links in the GitHub Actions summary.
- Improved title detection in CSV rows using common title column aliases.
- Improved warning context (especially region warnings) to reduce `Unknown` values.
- Simplified detailed report labels by removing the trailing total-games suffix.
- Removed the extra `Detailed Reports (Inline)` block from the workflow job summary.

## Validation
- Ran Tag Guardian locally on a single CSV and on the full dataset.
- Checked that report summaries now use concise labels.
- Checked that warnings and titles are more informative.

## Issue
Closes #98